### PR TITLE
feat(db): add automatic backup before sync with restore capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ next-env.d.ts
 db.json
 /data/db.json
 /data/db-demo.json
+/data/db-backup.json
 banking.config.json
 
 # Auto Claude data directory

--- a/src/actions/sync.actions.ts
+++ b/src/actions/sync.actions.ts
@@ -5,6 +5,7 @@ import { getAdapter, registerAdapter } from "@/lib/banking/adapters";
 import { dkbAdapter } from "@/lib/banking/adapters/dkb";
 import { syncBank } from "@/lib/banking/sync";
 import { getDb, invalidateDbCache, getDbMode } from "@/lib/db";
+import { DB_PATHS } from "@/lib/db/storage";
 import type { SyncMetadata } from "@/lib/banking/types";
 import { revalidatePath } from "next/cache";
 
@@ -98,4 +99,36 @@ export async function getSyncStatus(): Promise<{
     syncHistory: db.data.syncHistory.slice(-10), // Last 10 syncs
     hasCredentials: !!config,
   };
+}
+
+export async function restoreFromBackup(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const { copyFile, access } = await import("fs/promises");
+
+    const mode = getDbMode();
+    const targetPath = DB_PATHS[mode];
+    const backupPath = DB_PATHS.backup;
+
+    await access(backupPath);
+    await copyFile(backupPath, targetPath);
+    invalidateDbCache();
+
+    revalidatePath("/");
+    revalidatePath("/transactions");
+    revalidatePath("/insights");
+
+    return { success: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { success: false, error: "No backup file found." };
+    }
+    console.error("[Restore] Failed to restore from backup:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/src/actions/sync.actions.ts
+++ b/src/actions/sync.actions.ts
@@ -6,7 +6,10 @@ import { dkbAdapter } from "@/lib/banking/adapters/dkb";
 import { syncBank } from "@/lib/banking/sync";
 import { getDb, invalidateDbCache, getDbMode } from "@/lib/db";
 import { DB_PATHS } from "@/lib/db/storage";
+import type { OperationResult } from "@/lib/db/backup";
 import type { SyncMetadata } from "@/lib/banking/types";
+import { DatabaseSchema } from "@/lib/db/schema";
+import { copyFile, readFile } from "fs/promises";
 import { revalidatePath } from "next/cache";
 
 // Register adapters on module load
@@ -101,18 +104,30 @@ export async function getSyncStatus(): Promise<{
   };
 }
 
-export async function restoreFromBackup(): Promise<{
-  success: boolean;
-  error?: string;
-}> {
-  try {
-    const { copyFile, access } = await import("fs/promises");
+export async function restoreFromBackup(): Promise<OperationResult> {
+  // Prevent restore in demo mode — same guard as triggerSync
+  if (getDbMode() === "demo") {
+    return { success: false, error: "Cannot restore in demo mode." };
+  }
 
+  try {
     const mode = getDbMode();
     const targetPath = DB_PATHS[mode];
     const backupPath = DB_PATHS.backup;
 
-    await access(backupPath);
+    // Invalidate cache before overwriting to prevent stale writes
+    invalidateDbCache();
+
+    // Validate backup file against DB schema before restoring
+    const raw = await readFile(backupPath, "utf-8");
+    const parsed = DatabaseSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: "Backup file is corrupted or has invalid schema.",
+      };
+    }
+
     await copyFile(backupPath, targetPath);
     invalidateDbCache();
 

--- a/src/lib/banking/sync.ts
+++ b/src/lib/banking/sync.ts
@@ -7,11 +7,21 @@ import type {
   UnifiedAccount,
 } from "@/lib/banking/types";
 import { createTransactionId } from "@/lib/banking/utils";
+import { createBackup } from "@/lib/db/backup";
 
 export async function syncBank(
   adapter: BankAdapter,
   credentials: BankCredentials
 ): Promise<SyncMetadata> {
+  // Create backup of current DB state before sync
+  const backupResult = await createBackup();
+  if (!backupResult.success) {
+    console.warn(
+      "[Sync] Backup failed, proceeding with sync:",
+      backupResult.error
+    );
+  }
+
   const db = await getDb();
   const startTime = new Date();
 

--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -1,26 +1,37 @@
-import { copyFile, access } from "fs/promises";
+import { copyFile, mkdir } from "fs/promises";
+import { dirname } from "path";
 
 import { DB_PATHS } from "./storage";
-import { getDbMode } from "./index";
+import { getDb, getDbMode } from "./index";
+
+/** Structured result for backup/restore operations. */
+export interface OperationResult {
+  success: boolean;
+  error?: string;
+}
 
 /**
  * Creates a backup copy of the current database file before sync.
- * Uses fs.copyFile for atomic OS-level copy.
+ * Flushes in-memory DB state to disk first, then copies the file.
  * Non-throwing — backup failure should not block sync.
  */
-export async function createBackup(): Promise<{
-  success: boolean;
-  error?: string;
-}> {
+export async function createBackup(): Promise<OperationResult> {
   const mode = getDbMode();
   const sourcePath = DB_PATHS[mode];
   const backupPath = DB_PATHS.backup;
 
   try {
-    await access(sourcePath);
+    // Flush any in-memory mutations to disk before copying
+    const db = await getDb();
+    await db.write();
+
+    // Ensure backup directory exists
+    await mkdir(dirname(backupPath), { recursive: true });
+
     await copyFile(sourcePath, backupPath);
     return { success: true };
   } catch (error) {
+    // Source file doesn't exist (first run) — nothing to back up
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return { success: true };
     }

--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -1,0 +1,33 @@
+import { copyFile, access } from "fs/promises";
+
+import { DB_PATHS } from "./storage";
+import { getDbMode } from "./index";
+
+/**
+ * Creates a backup copy of the current database file before sync.
+ * Uses fs.copyFile for atomic OS-level copy.
+ * Non-throwing — backup failure should not block sync.
+ */
+export async function createBackup(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  const mode = getDbMode();
+  const sourcePath = DB_PATHS[mode];
+  const backupPath = DB_PATHS.backup;
+
+  try {
+    await access(sourcePath);
+    await copyFile(sourcePath, backupPath);
+    return { success: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { success: true };
+    }
+    console.error("[Backup] Failed to create backup:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- **Automatic pre-sync backup**: Before each bank sync operation, the current database file is copied to a backup location as a safety net
- **Restore capability**: New restoreFromBackup() server action allows recovering the pre-sync state if data corruption occurs
- **Non-blocking design**: Backup failures log a warning but never prevent sync from proceeding

## Changes

| File | Change | Purpose |
|------|--------|--------|
| src/lib/db/backup.ts | **NEW** | createBackup() utility using fs.copyFile for atomic file copy |
| src/lib/banking/sync.ts | **MODIFIED** | Call createBackup() as the first operation in syncBank() |
| src/actions/sync.actions.ts | **MODIFIED** | Add restoreFromBackup() server action + import DB_PATHS |

## Design Decisions

- **Simple file copy over rotation**: Single backup file (last pre-sync state) is sufficient for a local-only app
- **Backup in syncBank() not triggerSync()**: Covers all trigger paths including REST API route
- **Non-throwing**: Backup failure logs warning but sync proceeds
- **Uses existing infrastructure**: DB_PATHS.backup was already defined but never used

## Verification

- [x] npx tsc --noEmit - zero errors
- [x] npx prettier --check - all files formatted
- [x] npm run build - production build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic backup created before syncing banking data to reduce data-loss risk.
  * Restore capability to revert the app to a previously created backup.

* **Bug Fixes**
  * Improved error handling for backup/restore operations with clear user-facing results and UI consistency after restores.

* **Chores**
  * Backup artifact added to ignore list to avoid committing local backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->