### PR TITLE
fix(sync): accept DKB transactions without value date

### DIFF
--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -2,12 +2,29 @@
 
 **Current Phase:** Phase 9: Database Backup Before Sync ✅ COMPLETE
 **Current Sprint:** Data Safety & Reliability
-**Last Session:** 2026-02-27
+**Last Session:** 2026-04-02
 **Commit:** feat(db): add automatic backup before sync with restore capability (#14)
 
-**Current Work (2026-02-27):** Added automatic DB backup before sync with restore capability
+**Current Work (2026-04-02):** Fixed DKB sync validation to accept transactions without valueDate
 
 ### This session changes
+
+**Hotfix: DKB transactions without `valueDate`**
+
+Fixed DKB sync failures caused by transaction records that omit `attributes.valueDate`. The DKB transaction schemas now treat `valueDate` as optional, which allows sync to continue while preserving existing behavior that uses `bookingDate` as the authoritative transaction date.
+
+**Files Modified:**
+
+- `src/lib/banking/adapters/dkb/api.ts` — Made transaction `valueDate` optional during API response validation
+- `src/lib/banking/adapters/dkb/mapper.ts` — Kept mapper schema aligned by making `valueDate` optional there as well
+
+**Verification:**
+
+- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
+- ✅ Production build succeeds (`npm run build`)
+- ⚠️ `npm run lint` still fails due to pre-existing unrelated repository issues
+
+---
 
 **Phase 9: Database Backup Before Sync**
 

--- a/src/lib/banking/adapters/dkb/api.ts
+++ b/src/lib/banking/adapters/dkb/api.ts
@@ -125,7 +125,7 @@ const DkbMerchantSchema = z.object({
 const DkbTransactionAttributesSchema = z.object({
   status: z.string(),
   bookingDate: z.string(),
-  valueDate: z.string(),
+  valueDate: z.string().optional(),
   description: z.string().optional(),
   endToEndId: z.string().optional(),
   transactionType: z.string().optional(),
@@ -179,7 +179,7 @@ export class DkbApiError extends Error {
   constructor(
     message: string,
     public readonly statusCode?: number,
-    public readonly response?: unknown,
+    public readonly response?: unknown
   ) {
     super(message);
     this.name = "DkbApiError";
@@ -194,7 +194,10 @@ export class DkbAuthError extends DkbApiError {
 }
 
 export class DkbNetworkError extends DkbApiError {
-  constructor(message: string, public readonly originalError?: unknown) {
+  constructor(
+    message: string,
+    public readonly originalError?: unknown
+  ) {
     super(message);
     this.name = "DkbNetworkError";
   }
@@ -211,7 +214,7 @@ function buildHeaders(credentials: BankCredentials): HeadersInit {
 
 async function fetchWithErrorHandling(
   url: string,
-  credentials: BankCredentials,
+  credentials: BankCredentials
 ): Promise<unknown> {
   let response: Response;
 
@@ -223,7 +226,7 @@ async function fetchWithErrorHandling(
   } catch (error) {
     throw new DkbNetworkError(
       `Network request failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-      error,
+      error
     );
   }
 
@@ -231,7 +234,7 @@ async function fetchWithErrorHandling(
   if (!response.ok) {
     if (response.status === 401 || response.status === 403) {
       throw new DkbAuthError(
-        `Authentication failed (HTTP ${response.status}) - please refresh your DKB session credentials`,
+        `Authentication failed (HTTP ${response.status}) - please refresh your DKB session credentials`
       );
     }
 
@@ -242,12 +245,12 @@ async function fetchWithErrorHandling(
       errorBody = await response.text();
     }
 
-    console.log(errorBody)
+    console.log(errorBody);
 
     throw new DkbApiError(
       `DKB API request failed: HTTP ${response.status} ${response.statusText}`,
       response.status,
-      errorBody,
+      errorBody
     );
   }
 
@@ -256,7 +259,7 @@ async function fetchWithErrorHandling(
     return await response.json();
   } catch (error) {
     throw new DkbApiError(
-      `Failed to parse JSON response: ${error instanceof Error ? error.message : "Unknown error"}`,
+      `Failed to parse JSON response: ${error instanceof Error ? error.message : "Unknown error"}`
     );
   }
 }
@@ -273,7 +276,7 @@ async function fetchWithErrorHandling(
  * @throws {DkbApiError} For other API errors
  */
 export async function fetchDkbAccounts(
-  credentials: BankCredentials,
+  credentials: BankCredentials
 ): Promise<DkbAccount[]> {
   const url = `${DKB_BASE_URL}/accounts/accounts?filter[product.type][NEQ]=loan`;
 
@@ -283,7 +286,7 @@ export async function fetchDkbAccounts(
   const parsed = DkbAccountsResponseSchema.safeParse(data);
   if (!parsed.success) {
     throw new DkbApiError(
-      `Invalid accounts response format: ${parsed.error.message}`,
+      `Invalid accounts response format: ${parsed.error.message}`
     );
   }
 
@@ -307,7 +310,7 @@ export async function fetchDkbTransactions(
   accountId: string,
   credentials: BankCredentials,
   // Optional date range to restrict transactions (ISO date strings: YYYY-MM-DD)
-  range?: { from?: string; to?: string },
+  range?: { from?: string; to?: string }
 ): Promise<DkbTransaction[]> {
   const allTransactions: DkbTransaction[] = [];
   let nextCursor: string | undefined;
@@ -345,7 +348,7 @@ export async function fetchDkbTransactions(
     const parsed = DkbTransactionsResponseSchema.safeParse(data);
     if (!parsed.success) {
       throw new DkbApiError(
-        `Invalid transactions response format (page ${pageCount}): ${parsed.error.message}`,
+        `Invalid transactions response format (page ${pageCount}): ${parsed.error.message}`
       );
     }
 
@@ -358,7 +361,7 @@ export async function fetchDkbTransactions(
     // Safety check
     if (pageCount >= MAX_PAGES) {
       throw new DkbApiError(
-        `Pagination limit exceeded (${MAX_PAGES} pages) - possible infinite loop`,
+        `Pagination limit exceeded (${MAX_PAGES} pages) - possible infinite loop`
       );
     }
   } while (nextCursor);

--- a/src/lib/banking/adapters/dkb/mapper.ts
+++ b/src/lib/banking/adapters/dkb/mapper.ts
@@ -58,7 +58,7 @@ export const DkbTransactionResponseSchema = z.object({
   attributes: z.object({
     status: z.string(), // "booked", "pending"
     bookingDate: z.string(), // YYYY-MM-DD
-    valueDate: z.string(), // YYYY-MM-DD
+    valueDate: z.string().optional(), // YYYY-MM-DD
     description: z.string().optional(),
     endToEndId: z.string().optional(),
     transactionType: z.string().optional(), // e.g. "KARTENZAHLUNG", "UEBERWEISUNG"


### PR DESCRIPTION
## Summary
- allow DKB transaction payloads without ttributes.valueDate so sync no longer fails on page validation
- keep the mapper schema aligned with the API schema change
- document the hotfix and verification results in docs/PROJECT-STATE.md

## Verification
- 
px tsc --noEmit
- 
pm run build
- 
pm run lint still has pre-existing unrelated repository failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DKB transaction synchronization to handle transactions without a `valueDate` field, allowing these transactions to sync successfully. Transaction dates continue to be determined by the booking date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->