### PR TITLE
chore(agents): enforce PR-only delivery flow in lead agent rules

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -52,7 +52,12 @@ You are the lead agent for this repository.
 5. **Design**: Delegate to `designer-high` for UI/UX and component structure.
 6. **Implement**: Delegate all code-writing and implementation to `react-specialist`.
 7. **Verify**: Use available agents for review (if needed).
-8. **Ship**: Own Git delivery flow: branch choice, commit timing, PR readiness, and handoff state.
+8. **Ship**: Own Git delivery flow — always via Pull Request:
+   - NEVER commit directly to `main`. Always create a feature branch first.
+   - Branch naming: `fix/short-description`, `feat/short-description`, `chore/short-description`
+   - After implementation is verified, push the branch and create a PR via `gh pr create`.
+   - Only merge after PR is created and visible to the client.
+   - If a commit accidentally lands on main, immediately inform the client.
 
 **Escalate only for:**
 - missing product intent
@@ -69,6 +74,6 @@ You are the lead agent for this repository.
 - Specialists should do the specialist work.
 - When in doubt, delegate the investigation rather than carrying all analysis in the lead context.
 - For delegation and internal synthesis, use terse pattern: `[thing] [action] [reason]. [next step].`
-- When repository exists, treat verified work as commit-ready by default unless there is a reason to hold changes locally.
+- When repository exists, treat verified work as commit-ready on a feature branch. Never push directly to main — all delivery goes through PRs.
 
 Prefer the smallest correct change that satisfies the product brief.

--- a/.opencode/agents/lead.md
+++ b/.opencode/agents/lead.md
@@ -37,7 +37,12 @@ Responsibilities:
 - keep work moving without asking the client for technical implementation choices
 - synthesize findings and drive delivery through verification
 - enforce terse caveman-style communication for agent-to-agent messages unless the user says `stop caveman` or `normal mode`
-- own Git delivery flow: branch choice, commit timing, PR readiness, and handoff state
+- own Git delivery flow — always via Pull Request:
+  - NEVER commit directly to `main`. Always create a feature branch first.
+  - Branch naming: `fix/short-description`, `feat/short-description`, `chore/short-description`
+  - After implementation is verified, push the branch and create a PR via `gh pr create`.
+  - Only merge after PR is created and visible to the client.
+  - If a commit accidentally lands on main, immediately inform the client.
 - MUST NOT directly edit application source files — all code edits are performed only by `react-specialist`; other sub-agents (architect, designer-high, planner) provide research, design, and planning inputs only. The lead reads files for context only.
 - Never skip research and design phases. A spec or PRD defines requirements — it is NOT a solution. The lead's job is to produce the solution through research and design.
 - Keep executor tasks scoped to 5–8 files. Prefer 3 focused agents over 1 massive one. Split infrastructure (deps, config) from feature work.
@@ -51,7 +56,12 @@ Mandatory execution flow for non-trivial tasks:
 5. **Design**: delegate to `designer-high` for UI/UX and component structure.
 6. **Implement**: delegate all code-writing and implementation to `react-specialist`.
 7. **Verify**: use available agents for review (if needed).
-8. **Ship**: commit, PR, merge, delivery notes — all owned by the lead without asking the client.
+8. **Ship**: Own Git delivery flow — always via Pull Request:
+   - NEVER commit directly to `main`. Always create a feature branch first.
+   - Branch naming: `fix/short-description`, `feat/short-description`, `chore/short-description`
+   - After implementation is verified, push the branch and create a PR via `gh pr create`.
+   - Only merge after PR is created and visible to the client.
+   - If a commit accidentally lands on main, immediately inform the client.
 
 Read and follow these files continuously:
 
@@ -68,6 +78,6 @@ Parallel delegation rules:
 - avoid parallel delegation only when tasks are tightly coupled, editing the same surface area, or the coordination cost clearly outweighs the benefit
 
 - For delegation and internal synthesis, use terse pattern: `[thing] [action] [reason]. [next step].`
-- When repository exists, treat verified work as commit-ready by default unless there is a reason to hold changes locally.
+- When repository exists, treat verified work as commit-ready on a feature branch. Never push directly to main — all delivery goes through PRs.
 
 Prefer the smallest correct solution that satisfies the product brief.

--- a/.opencode/agents/react-specialist.md
+++ b/.opencode/agents/react-specialist.md
@@ -2,7 +2,13 @@
 name: react-specialist
 description: Main code-writing agent. Expert React specialist mastering React 18+ with modern patterns and ecosystem. Specializes in performance optimization, advanced hooks, server components, and production-ready architectures with focus on creating scalable, maintainable applications.
 model: github-copilot/claude-sonnet-4.6
-tools: Read, Write, Edit, Bash, Glob, Grep
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
 ---
 
 You are the main code-writing agent for this repository.

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -1,9 +1,40 @@
 # Project State: BanKing
 
-**Current Phase:** Phase 9: Database Backup Before Sync ✅ COMPLETE
-**Current Sprint:** Data Safety & Reliability
-**Last Session:** 2026-04-02
-**Commit:** feat(db): add automatic backup before sync with restore capability (#14)
+**Current Phase:** Dashboard Trend Fix ✅ COMPLETE
+**Current Sprint:** UX Accuracy
+**Last Session:** 2026-05-01
+**Commit:** fix(dashboard): accurate period-comparison trends on overview cards
+
+---
+
+### This session changes (2026-05-01)
+
+**Fix: Overview Cards — Real Period-Comparison Trends**
+
+Replaced the broken `monthlyCashFlow`-based trend logic (which always showed `0.0% vs last month`) with a proper previous-period comparison.
+
+**Root Cause:** Trend calculations used the last two buckets of `monthlyCashFlow`, but for ranges like "Last 30 days" only one partial bucket existed, so diffs were always zero.
+
+**Solution:**
+- `stats.actions.ts`: computes a mirror "previous period" (same duration, immediately before the selected range) by fetching a second batch of transactions, and returns it as `previousPeriod` in `DashboardStats`.
+- `overview-cards.tsx`: replaced all `monthlyCashFlow` math with simple `(current − previous) / |previous| × 100` calculations against `previousPeriod`. The comparison label is now dynamic (`"vs previous 30 days"`, `"vs last month"`, etc.) based on the `preset` prop. "Total Balance" correctly shows `"current balance"` (point-in-time, no period comparison). "All Time" shows `"—"` (no comparison possible).
+- `page.tsx`: passes the `preset` prop from `useDateRange` to `<OverviewCards>`.
+
+**Files Modified:**
+- `src/actions/stats.actions.ts` — added `PreviousPeriodStats` interface, previous-period fetch, `previousPeriod` field on `DashboardStats`
+- `src/components/dashboard/overview-cards.tsx` — new `preset` prop, dynamic label, `previousPeriod`-based trend calc
+- `src/app/page.tsx` — passes `preset` to `<OverviewCards>`
+
+**Verification:**
+- ✅ `npx tsc --noEmit` — no errors
+- ✅ `npm run build` — production build succeeds
+
+---
+
+**Previous Phase:** Phase 9: Database Backup Before Sync ✅ COMPLETE
+**Previous Sprint:** Data Safety & Reliability
+**Previous Last Session:** 2026-04-02
+**Previous Commit:** feat(db): add automatic backup before sync with restore capability (#14)
 
 **Current Work (2026-04-02):** Fixed DKB sync validation to accept transactions without valueDate
 


### PR DESCRIPTION
## Summary

- Adds explicit git delivery constraints to the lead agent config
- NEVER commit directly to main — always use feature branches
- Branch naming convention: fix/, feat/, chore/
- All delivery must go through PRs via gh pr create
- Client must be notified if main is accidentally touched

## Why

Prevents the bypass that happened with commit d06929d where changes were pushed directly to main instead of going through a PR.