### PR TITLE
feat(dashboard): monthly averages (income / spending / net) + multi-month ranges

### DIFF
--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -7,6 +7,25 @@
 
 ---
 
+## This session changes (2026-06-01) — Fix: CodeRabbit PR #22 review findings
+
+**Summary:** Addressed CodeRabbit review findings on the Monthly Averages PR. Removed a PII debug log, corrected `fetchData` useCallback dependency array, fixed partial-month label consistency in card bodies, and demoted stale "Current Sprint" heading in PROJECT-STATE.md.
+
+**Files Modified:**
+
+- `src/app/page.tsx` — Removed `console.log(transactionsData)` PII leak; added `preset` and `setCustomRange` to `fetchData` useCallback deps (satisfies `react-hooks/exhaustive-deps`)
+- `src/components/dashboard/monthly-average-cards.tsx` — Card body now conditionally shows "period total" / "for the selected period" when `isPartialMonth` is true, instead of always showing "/ month" / "across N month(s)"
+- `docs/PROJECT-STATE.md` — Renamed `## Current Sprint: Sync Error UI Enhancement` to `## Previous Sprint:` so only the top-level header block indicates the active sprint
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean (no errors)
+- `npm run build` — succeeds (all 9 routes emitted)
+- `npx prettier --write` — all 3 changed files reported unchanged (already formatted)
+- `npm run lint` — 44 pre-existing problems; zero new issues introduced; `exhaustive-deps` warning for `fetchData` is gone (fixed by dep array update)
+
+---
+
 ## This session changes (2026-06-01) — Feature: Monthly Averages (avg income / spending / net cash flow)
 
 **Summary:** Added a "Monthly Averages" dashboard section showing average-per-month income, spending, and net cash flow over the selected date range, plus new "Last 3/6/12 Months" date-range presets. Month-count divisor is duration-based (elapsed days / 30.44, rounded, min 1) so a "Last 3 Months" range divides by 3 — matching the user's mental model rather than calendar-boundary counting. Averages are computed server-side in `getDashboardStats` and surfaced via a new `DashboardStats.averages` field. The averages cards intentionally use reduced-opacity Neo-Glass styling vs the totals row to read as a derived/secondary metric, with a labeled "Monthly Averages" section heading and a "/ month" suffix to prevent confusion with totals. A partial-month (<28 days) range shows an amber note and falls back to the period total.
@@ -304,7 +323,7 @@ Implemented a complete error handling system for bank synchronization failures f
 
 ---
 
-## Current Sprint: Sync Error UI Enhancement ✅ COMPLETE
+## Previous Sprint: Sync Error UI Enhancement ✅ COMPLETE
 
 ### Phase 7 Overview
 

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -1,9 +1,35 @@
 # Project State: BanKing
 
 **Current Phase:** Account Management UI ✅ COMPLETE
-**Current Sprint:** Closed/Stale Account Visibility
+**Current Sprint:** Monthly Averages Feature
 **Last Session:** 2026-06-01
-**Branch:** fix/total-balance-excludes-closed-accounts
+**Branch:** feat/monthly-average-metrics
+
+---
+
+## This session changes (2026-06-01) — Feature: Monthly Averages (avg income / spending / net cash flow)
+
+**Summary:** Added a "Monthly Averages" dashboard section showing average-per-month income, spending, and net cash flow over the selected date range, plus new "Last 3/6/12 Months" date-range presets. Month-count divisor is duration-based (elapsed days / 30.44, rounded, min 1) so a "Last 3 Months" range divides by 3 — matching the user's mental model rather than calendar-boundary counting. Averages are computed server-side in `getDashboardStats` and surfaced via a new `DashboardStats.averages` field. The averages cards intentionally use reduced-opacity Neo-Glass styling vs the totals row to read as a derived/secondary metric, with a labeled "Monthly Averages" section heading and a "/ month" suffix to prevent confusion with totals. A partial-month (<28 days) range shows an amber note and falls back to the period total.
+
+**Files Created:**
+
+- `src/components/dashboard/monthly-average-cards.tsx` — labeled section + 3 reduced-opacity average cards (income/spending/net), loading/error states, null when no income & no expenses
+
+**Files Modified:**
+
+- `src/hooks/use-date-range.ts` — added last3months/last6months/last12months presets
+- `src/components/dashboard/date-range-picker.tsx` — added the 3 preset buttons
+- `src/components/dashboard/overview-cards.tsx` — added trend labels for the new presets
+- `src/lib/stats/calculations.ts` — added `calculateMonthlyAverages()` + `MonthlyAveragesInput`/`Result` types (duration-based month count, `isPartialMonth` flag)
+- `src/actions/stats.actions.ts` — added `MonthlyAverages` interface, `averages` field on `DashboardStats`, wired the calculation
+- `src/app/page.tsx` — mounted `<MonthlyAverageCards>` between overview cards and charts; adjusted stagger delays
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean
+- `npm run build` — succeeds
+- `npx prettier --check .` — passes
+- `npm run lint` — no new errors (pre-existing issues unchanged)
 
 ---
 

--- a/src/actions/stats.actions.ts
+++ b/src/actions/stats.actions.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { differenceInDays, parseISO, subDays } from "date-fns";
-import { getTransactions, type TransactionFilters } from "./transactions.actions";
+import {
+  getTransactions,
+  type TransactionFilters,
+} from "./transactions.actions";
 import {
   calculateMonthlyCashFlow,
   calculateSavingsRateLegacy,
@@ -10,8 +13,17 @@ import {
   calculateExpenseVolatilityLegacy,
   calculateMonthOverMonthTrend,
   calculateEmergencyFundCoverage,
+  calculateMonthlyAverages,
 } from "@/lib/stats/calculations";
 import { getTotalBalance } from "./accounts.actions";
+
+export interface MonthlyAverages {
+  avgMonthlyIncome: number;
+  avgMonthlyExpenses: number;
+  avgMonthlyNet: number;
+  monthsCount: number;
+  isPartialMonth: boolean;
+}
 
 export interface PreviousPeriodStats {
   totalIncome: number;
@@ -28,16 +40,25 @@ export interface DashboardStats {
   netCashFlow: number;
   expenseToIncomeRatio: number;
   savingsRate: number;
-  monthlyCashFlow: { month: string; income: number; expenses: number; net: number }[];
+  monthlyCashFlow: {
+    month: string;
+    income: number;
+    expenses: number;
+    net: number;
+  }[];
   categoryBreakdown: { category: string; amount: number; percentage: number }[];
   dailyAverageSpend: number;
   expenseVolatility: number;
   monthOverMonthTrend: number;
   emergencyFundCoverage: number;
   previousPeriod: PreviousPeriodStats | null;
+  averages: MonthlyAverages;
 }
 
-function computePeriodStats(income: number, expenses: number): PreviousPeriodStats {
+function computePeriodStats(
+  income: number,
+  expenses: number
+): PreviousPeriodStats {
   return {
     totalIncome: income,
     totalExpenses: expenses,
@@ -48,7 +69,7 @@ function computePeriodStats(income: number, expenses: number): PreviousPeriodSta
 }
 
 export async function getDashboardStats(
-  filters?: TransactionFilters,
+  filters?: TransactionFilters
 ): Promise<DashboardStats> {
   // Build previous-period filters when both startDate and endDate are present
   let prevFilters: TransactionFilters | undefined;
@@ -94,6 +115,14 @@ export async function getDashboardStats(
     previousPeriod = computePeriodStats(prevIncome, prevExpenses);
   }
 
+  const averages = calculateMonthlyAverages({
+    totalIncome: income,
+    totalExpenses: expenses,
+    netCashFlow: income - expenses,
+    startDate: filters?.startDate,
+    endDate: filters?.endDate,
+  });
+
   return {
     totalBalance,
     totalIncome: income,
@@ -103,10 +132,19 @@ export async function getDashboardStats(
     savingsRate: calculateSavingsRateLegacy(income, expenses),
     monthlyCashFlow: calculateMonthlyCashFlow(transactions),
     categoryBreakdown: calculateCategoryBreakdown(transactions),
-    dailyAverageSpend: calculateDailyAverageSpend(transactions, filters?.startDate, filters?.endDate),
+    dailyAverageSpend: calculateDailyAverageSpend(
+      transactions,
+      filters?.startDate,
+      filters?.endDate
+    ),
     expenseVolatility: calculateExpenseVolatilityLegacy(transactions),
     monthOverMonthTrend: calculateMonthOverMonthTrend(transactions),
-    emergencyFundCoverage: calculateEmergencyFundCoverage(totalBalance, expenses, transactions),
+    emergencyFundCoverage: calculateEmergencyFundCoverage(
+      totalBalance,
+      expenses,
+      transactions
+    ),
     previousPeriod,
+    averages,
   };
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,8 +81,6 @@ export default function Home() {
         getDashboardStats(filters),
       ]);
 
-      console.log(transactionsData);
-
       // If the user selected 'allTime', update the date-range hook to the true data span (excluding internals)
       if (isAllTime && transactionsData && transactionsData.length > 0) {
         // Compute min/max bookingDate
@@ -110,7 +108,7 @@ export default function Home() {
     } finally {
       setLoading(false);
     }
-  }, [startDate, endDate, selectedAccountId]);
+  }, [startDate, endDate, selectedAccountId, preset, setCustomRange]);
 
   // Fetch data when filters change
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, useCallback } from "react";
 import { motion } from "motion/react";
 import { DashboardShell } from "@/components/dashboard/dashboard-shell";
 import { OverviewCards } from "@/components/dashboard/overview-cards";
+import { MonthlyAverageCards } from "@/components/dashboard/monthly-average-cards";
 import { BalanceHistoryChart } from "@/components/dashboard/balance-history-chart";
 import { IncomeExpensesChart } from "@/components/dashboard/income-expenses-chart";
 import { CategoryBreakdownChart } from "@/components/dashboard/category-breakdown-chart";
@@ -270,13 +271,32 @@ export default function Home() {
         />
       </MotionDiv>
 
+      {/* Monthly Average Cards */}
+      <MotionDiv
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+        key={`averages-${startDate}-${endDate}-${selectedAccountId}`}
+      >
+        <MonthlyAverageCards
+          filters={{
+            startDate,
+            endDate,
+            ...(selectedAccountId !== "all" && {
+              accountId: selectedAccountId,
+            }),
+          }}
+          preset={preset}
+        />
+      </MotionDiv>
+
       {/* Charts Grid */}
       <div className="grid items-stretch gap-6 lg:grid-cols-2">
         {/* Balance History Chart */}
         <MotionDiv
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.4, delay: 0.2 }}
+          transition={{ duration: 0.4, delay: 0.25 }}
           className="h-full"
         >
           <BalanceHistoryChart
@@ -291,7 +311,7 @@ export default function Home() {
         <MotionDiv
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.4, delay: 0.25 }}
+          transition={{ duration: 0.4, delay: 0.3 }}
           className="h-full"
         >
           <CategoryBreakdownChart
@@ -305,7 +325,7 @@ export default function Home() {
       <MotionDiv
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, delay: 0.3 }}
+        transition={{ duration: 0.4, delay: 0.35 }}
       >
         <IncomeExpensesChart transactions={filteredTransactions} />
       </MotionDiv>
@@ -315,7 +335,7 @@ export default function Home() {
         <MotionDiv
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 0.3, delay: 0.35 }}
+          transition={{ duration: 0.3, delay: 0.4 }}
           className="text-muted-foreground flex items-center justify-center gap-6 border-t border-white/5 pt-6 text-sm"
         >
           <span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,8 @@ import { CategoryBreakdownChart } from "@/components/dashboard/category-breakdow
 import { DateRangePicker } from "@/components/dashboard/date-range-picker";
 import { useDateRange } from "@/hooks/use-date-range";
 import { getTransactions } from "@/actions/transactions.actions";
+import { getDashboardStats } from "@/actions/stats.actions";
+import type { DashboardStats } from "@/actions/stats.actions";
 import { getAccounts } from "@/actions/accounts.actions";
 import type { UnifiedTransaction, UnifiedAccount } from "@/lib/banking/types";
 import { format } from "date-fns";
@@ -37,6 +39,9 @@ export default function Home() {
   const [selectedAccountId, setSelectedAccountId] = useState<string>("all");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dashboardStats, setDashboardStats] = useState<DashboardStats | null>(
+    null
+  );
 
   // Convert date range to ISO strings for filtering
   const startDate = format(range.from, "yyyy-MM-dd");
@@ -61,6 +66,7 @@ export default function Home() {
     try {
       setLoading(true);
       setError(null);
+      setDashboardStats(null);
 
       // Build filters. If preset is 'allTime', omit date filters to fetch all transactions
       const isAllTime = preset === "allTime";
@@ -69,10 +75,11 @@ export default function Home() {
         ...(selectedAccountId !== "all" && { accountId: selectedAccountId }),
       };
 
-      // Fetch transactions with filters, excluding internal transfers by default
-      const transactionsData = await getTransactions(filters, {
-        excludeInternal: true,
-      });
+      // Fetch transactions and dashboard stats in parallel
+      const [transactionsData, statsData] = await Promise.all([
+        getTransactions(filters, { excludeInternal: true }),
+        getDashboardStats(filters),
+      ]);
 
       console.log(transactionsData);
 
@@ -94,8 +101,9 @@ export default function Home() {
         }
       }
 
-      // Set transactions
+      // Set transactions and stats
       setTransactions(transactionsData);
+      setDashboardStats(statsData);
     } catch (err) {
       console.error("Failed to fetch transactions:", err);
       setError(err instanceof Error ? err.message : "Failed to load data");
@@ -268,6 +276,7 @@ export default function Home() {
             }),
           }}
           preset={preset}
+          stats={dashboardStats}
         />
       </MotionDiv>
 
@@ -286,7 +295,7 @@ export default function Home() {
               accountId: selectedAccountId,
             }),
           }}
-          preset={preset}
+          stats={dashboardStats}
         />
       </MotionDiv>
 

--- a/src/components/dashboard/date-range-picker.tsx
+++ b/src/components/dashboard/date-range-picker.tsx
@@ -30,6 +30,9 @@ const presets: Array<{ label: string; value: DateRangePreset }> = [
   { label: "Last 30 days", value: "last30days" },
   { label: "This Month", value: "thisMonth" },
   { label: "Last Month", value: "lastMonth" },
+  { label: "Last 3 Months", value: "last3months" },
+  { label: "Last 6 Months", value: "last6months" },
+  { label: "Last 12 Months", value: "last12months" },
   { label: "This Year", value: "thisYear" },
   { label: "Last Year", value: "lastYear" },
   { label: "All Time", value: "allTime" },
@@ -88,28 +91,28 @@ export function DateRangePicker({
           variant="outline"
           className={cn(
             "justify-start text-left font-normal",
-            "bg-card/50 backdrop-blur-xl border-white/10 dark:border-white/5",
+            "bg-card/50 border-white/10 backdrop-blur-xl dark:border-white/5",
             "hover:bg-card/70 hover:border-primary/20",
             "transition-all duration-200",
             className
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4 text-primary" />
+          <CalendarIcon className="text-primary mr-2 h-4 w-4" />
           <span className="truncate">{displayText}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent
         className={cn(
           "w-auto p-0",
-          "bg-card/95 backdrop-blur-xl border-white/10 dark:border-white/5",
-          "shadow-xl shadow-primary/5"
+          "bg-card/95 border-white/10 backdrop-blur-xl dark:border-white/5",
+          "shadow-primary/5 shadow-xl"
         )}
         align="start"
       >
         <div className="flex flex-col gap-2 p-3 md:flex-row">
           {/* Preset Buttons */}
           <div className="flex flex-col gap-1.5">
-            <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium uppercase tracking-wide">
+            <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium tracking-wide uppercase">
               Quick Select
             </div>
             {presets.map((presetItem, index) => (
@@ -135,8 +138,8 @@ export function DateRangePicker({
           </div>
 
           {/* Calendar */}
-          <div className="border-t pt-3 md:border-l md:border-t-0 md:pl-3 md:pt-0">
-            <div className="text-muted-foreground mb-2 px-2 text-xs font-medium uppercase tracking-wide">
+          <div className="border-t pt-3 md:border-t-0 md:border-l md:pt-0 md:pl-3">
+            <div className="text-muted-foreground mb-2 px-2 text-xs font-medium tracking-wide uppercase">
               Custom Range
             </div>
             <Calendar

--- a/src/components/dashboard/monthly-average-cards.tsx
+++ b/src/components/dashboard/monthly-average-cards.tsx
@@ -221,10 +221,12 @@ function MonthlyAverageCardsView({
                 {card.amount}
               </h3>
               <p className="text-muted-foreground/80 mt-0.5 text-xs font-medium">
-                / month
+                {isPartialMonth ? "period total" : "/ month"}
               </p>
               <p className="text-muted-foreground mt-2 text-sm">
-                across {monthsCount} month{monthsCount === 1 ? "" : "s"}
+                {isPartialMonth
+                  ? "for the selected period"
+                  : `across ${monthsCount} month${monthsCount === 1 ? "" : "s"}`}
               </p>
             </CardContent>
           </MotionCard>

--- a/src/components/dashboard/monthly-average-cards.tsx
+++ b/src/components/dashboard/monthly-average-cards.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { ArrowUpRight, ArrowDownRight, Scale, BarChart3 } from "lucide-react";
+import { motion } from "motion/react";
+import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useEffect, useState } from "react";
+import { getDashboardStats } from "@/actions/stats.actions";
+import type { MonthlyAverages } from "@/actions/stats.actions";
+import type { TransactionFilters } from "@/actions/transactions.actions";
+import type { DateRangePreset } from "@/hooks/use-date-range";
+
+const MotionCard = motion.create(Card);
+
+interface MonthlyAverageCardsProps {
+  filters?: TransactionFilters;
+  preset?: DateRangePreset;
+}
+
+const formatCurrency = (amount: number): string => {
+  return new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+};
+
+export function MonthlyAverageCards({
+  filters,
+}: MonthlyAverageCardsProps) {
+  const [averages, setAverages] = useState<MonthlyAverages | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setAverages(null);
+        setError(null);
+        const stats = await getDashboardStats(filters);
+        setAverages(stats.averages);
+      } catch (err) {
+        console.error("Failed to fetch monthly averages:", err);
+        setError(err instanceof Error ? err.message : "Failed to load data");
+      }
+    }
+
+    fetchData();
+  }, [filters]);
+
+  // Loading state
+  if (!averages && !error) {
+    return (
+      <div>
+        <div className="mb-4 flex items-center gap-3">
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-36" />
+          <div className="h-px flex-1 bg-gradient-to-r from-white/10 to-transparent" />
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {[...Array(3)].map((_, index) => (
+            <Card
+              key={index}
+              className="relative overflow-hidden border-white/5"
+            >
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-8 w-8 rounded-xl" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="mb-1 h-9 w-32" />
+                <Skeleton className="mb-2 h-3 w-16" />
+                <Skeleton className="h-4 w-28" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="border-rose-500/20 md:col-span-3">
+          <CardContent className="flex items-center justify-center p-6">
+            <p className="text-sm text-rose-400">
+              Failed to load monthly averages: {error}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Empty data — hide the section rather than showing zeros
+  if (averages!.avgMonthlyIncome === 0 && averages!.avgMonthlyExpenses === 0) {
+    return null;
+  }
+
+  const {
+    avgMonthlyIncome,
+    avgMonthlyExpenses,
+    avgMonthlyNet,
+    monthsCount,
+    isPartialMonth,
+  } = averages!;
+
+  const netIsNegative = avgMonthlyNet < 0;
+
+  const cards = [
+    {
+      title: "Avg. Monthly Income",
+      icon: ArrowUpRight,
+      amount: formatCurrency(avgMonthlyIncome),
+      overlay: "from-emerald-500/10 to-teal-500/10",
+      border: "border-emerald-500/10",
+      textGradient: "from-emerald-300 to-teal-300",
+    },
+    {
+      title: "Avg. Monthly Spending",
+      icon: ArrowDownRight,
+      amount: formatCurrency(avgMonthlyExpenses),
+      overlay: "from-rose-500/10 to-orange-500/10",
+      border: "border-rose-500/10",
+      textGradient: "from-rose-300 to-orange-300",
+    },
+    {
+      title: "Avg. Monthly Net",
+      icon: Scale,
+      amount: formatCurrency(avgMonthlyNet),
+      overlay: netIsNegative
+        ? "from-rose-500/10 to-red-500/10"
+        : "from-cyan-500/10 to-blue-500/10",
+      border: netIsNegative ? "border-rose-500/10" : "border-cyan-500/10",
+      textGradient: netIsNegative
+        ? "from-rose-300 to-red-300"
+        : "from-cyan-300 to-blue-300",
+    },
+  ];
+
+  return (
+    <div>
+      {/* Section heading */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <BarChart3 className="text-muted-foreground h-4 w-4" />
+        <h2 className="text-muted-foreground text-sm font-semibold tracking-wider uppercase">
+          Monthly Averages
+        </h2>
+        <div className="h-px flex-1 bg-gradient-to-r from-white/10 to-transparent" />
+        {isPartialMonth ? (
+          <span className="text-xs text-amber-400/80">
+            Partial month — showing period total
+          </span>
+        ) : (
+          <span className="text-muted-foreground text-xs">
+            over {monthsCount} month{monthsCount === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      {/* Cards grid */}
+      <div className="grid gap-6 md:grid-cols-3">
+        {cards.map((card, index) => (
+          <MotionCard
+            key={card.title}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.1 }}
+            className={`relative overflow-hidden ${card.border}`}
+          >
+            <div
+              className={`absolute inset-0 bg-gradient-to-br ${card.overlay} opacity-50`}
+            />
+
+            <CardHeader className="relative z-10 flex flex-row items-center justify-between pb-2">
+              <p className="text-muted-foreground text-sm font-medium">
+                {card.title}
+              </p>
+              <div className="bg-background/20 rounded-xl p-2 backdrop-blur-md">
+                <card.icon className="h-4 w-4 text-current opacity-80" />
+              </div>
+            </CardHeader>
+
+            <CardContent className="relative z-10">
+              <h3
+                className={`bg-gradient-to-r text-3xl font-bold ${card.textGradient} bg-clip-text text-transparent`}
+              >
+                {card.amount}
+              </h3>
+              <p className="text-muted-foreground/80 mt-0.5 text-xs font-medium">
+                / month
+              </p>
+              <p className="text-muted-foreground mt-2 text-sm">
+                across {monthsCount} month{monthsCount === 1 ? "" : "s"}
+              </p>
+            </CardContent>
+          </MotionCard>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/monthly-average-cards.tsx
+++ b/src/components/dashboard/monthly-average-cards.tsx
@@ -6,15 +6,14 @@ import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useEffect, useState } from "react";
 import { getDashboardStats } from "@/actions/stats.actions";
-import type { MonthlyAverages } from "@/actions/stats.actions";
+import type { DashboardStats, MonthlyAverages } from "@/actions/stats.actions";
 import type { TransactionFilters } from "@/actions/transactions.actions";
-import type { DateRangePreset } from "@/hooks/use-date-range";
 
 const MotionCard = motion.create(Card);
 
 interface MonthlyAverageCardsProps {
   filters?: TransactionFilters;
-  preset?: DateRangePreset;
+  stats?: DashboardStats | null;
 }
 
 const formatCurrency = (amount: number): string => {
@@ -26,9 +25,15 @@ const formatCurrency = (amount: number): string => {
   }).format(amount);
 };
 
-export function MonthlyAverageCards({
+/**
+ * Inner component that handles the self-fetch path (no stats prop provided).
+ * Keeping it separate avoids calling hooks conditionally in the outer component.
+ */
+function MonthlyAverageCardsSelfFetch({
   filters,
-}: MonthlyAverageCardsProps) {
+}: {
+  filters?: TransactionFilters;
+}) {
   const [averages, setAverages] = useState<MonthlyAverages | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,17 +42,43 @@ export function MonthlyAverageCards({
       try {
         setAverages(null);
         setError(null);
-        const stats = await getDashboardStats(filters);
-        setAverages(stats.averages);
+        const fetched = await getDashboardStats(filters);
+        setAverages(fetched.averages);
       } catch (err) {
         console.error("Failed to fetch monthly averages:", err);
         setError(err instanceof Error ? err.message : "Failed to load data");
       }
     }
-
     fetchData();
   }, [filters]);
 
+  return <MonthlyAverageCardsView averages={averages} error={error} />;
+}
+
+export function MonthlyAverageCards({
+  filters,
+  stats: statsProp,
+}: MonthlyAverageCardsProps) {
+  // When the parent provides stats, derive averages directly — no effect needed.
+  if (statsProp !== undefined) {
+    return (
+      <MonthlyAverageCardsView
+        averages={statsProp ? statsProp.averages : null}
+        error={null}
+      />
+    );
+  }
+
+  return <MonthlyAverageCardsSelfFetch filters={filters} />;
+}
+
+function MonthlyAverageCardsView({
+  averages,
+  error,
+}: {
+  averages: MonthlyAverages | null;
+  error: string | null;
+}) {
   // Loading state
   if (!averages && !error) {
     return (

--- a/src/components/dashboard/overview-cards.tsx
+++ b/src/components/dashboard/overview-cards.tsx
@@ -69,6 +69,12 @@ function getTrendLabel(preset: DateRangePreset | undefined): string | null {
       return "vs last month";
     case "lastMonth":
       return "vs month before";
+    case "last3months":
+      return "vs previous 3 months";
+    case "last6months":
+      return "vs previous 6 months";
+    case "last12months":
+      return "vs previous 12 months";
     case "thisYear":
       return "vs last year";
     case "lastYear":

--- a/src/components/dashboard/overview-cards.tsx
+++ b/src/components/dashboard/overview-cards.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useEffect, useState } from "react";
 import { getDashboardStats } from "@/actions/stats.actions";
+import type { DashboardStats } from "@/actions/stats.actions";
 import { getAccounts, getActiveAccountIds } from "@/actions/accounts.actions";
 import type { TransactionFilters } from "@/actions/transactions.actions";
 import type { DateRangePreset } from "@/hooks/use-date-range";
@@ -42,6 +43,7 @@ interface CardData {
 interface OverviewCardsProps {
   filters?: TransactionFilters;
   preset?: DateRangePreset;
+  stats?: DashboardStats | null;
 }
 
 const formatCurrency = (amount: number): string => {
@@ -94,9 +96,161 @@ function pctChange(current: number, previous: number): number | null {
   return ((current - previous) / Math.abs(previous)) * 100;
 }
 
-export function OverviewCards({ filters, preset }: OverviewCardsProps) {
+/** Pure function: converts a DashboardStats snapshot into card display data. */
+function buildCardData(
+  stats: DashboardStats,
+  preset: DateRangePreset | undefined
+): CardData[] {
+  const trendLabel = getTrendLabel(preset);
+  const prev = stats.previousPeriod;
+
+  const makeTrend = (
+    pct: number | null
+  ): { change: string; trend: "up" | "down" | "neutral" } => {
+    if (pct === null || trendLabel === null) {
+      return { change: "—", trend: "neutral" };
+    }
+    return {
+      change: formatPercentage(pct),
+      trend: pct > 0 ? "up" : pct < 0 ? "down" : "neutral",
+    };
+  };
+
+  const incomeTrend = makeTrend(
+    prev ? pctChange(stats.totalIncome, prev.totalIncome) : null
+  );
+  const expensesTrend = makeTrend(
+    prev ? pctChange(stats.totalExpenses, prev.totalExpenses) : null
+  );
+  const cashFlowTrend = makeTrend(
+    prev ? pctChange(stats.netCashFlow, prev.netCashFlow) : null
+  );
+  const savingsTrend = makeTrend(
+    prev ? pctChange(stats.savingsRate, prev.savingsRate) : null
+  );
+  const ratioTrend = makeTrend(
+    prev
+      ? pctChange(stats.expenseToIncomeRatio, prev.expenseToIncomeRatio)
+      : null
+  );
+
+  const sharedLabel = trendLabel ?? "—";
+
+  return [
+    {
+      title: "Total Balance",
+      amount: formatCurrency(stats.totalBalance),
+      // Balance is a point-in-time value — no period comparison makes sense
+      change: "—",
+      trendLabel: "current balance",
+      trend: "neutral",
+      icon: Wallet,
+      gradient: "from-blue-500/20 to-purple-500/20",
+      border: "border-blue-500/20",
+      textGradient: "from-blue-400 to-purple-400",
+    },
+    {
+      title: "Income",
+      amount: formatCurrency(stats.totalIncome),
+      change: incomeTrend.change,
+      trendLabel: sharedLabel,
+      trend: incomeTrend.trend,
+      icon: ArrowUpRight,
+      gradient: "from-emerald-500/20 to-teal-500/20",
+      border: "border-emerald-500/20",
+      textGradient: "from-emerald-400 to-teal-400",
+    },
+    {
+      title: "Expenses",
+      amount: formatCurrency(stats.totalExpenses),
+      change: expensesTrend.change,
+      trendLabel: sharedLabel,
+      trend: expensesTrend.trend,
+      icon: ArrowDownRight,
+      gradient: "from-rose-500/20 to-orange-500/20",
+      border: "border-rose-500/20",
+      textGradient: "from-rose-400 to-orange-400",
+    },
+    {
+      title: "Net Cash Flow",
+      amount: formatCurrency(stats.netCashFlow),
+      change: cashFlowTrend.change,
+      trendLabel: sharedLabel,
+      trend: cashFlowTrend.trend,
+      icon: Coins,
+      gradient: "from-cyan-500/20 to-blue-500/20",
+      border: "border-cyan-500/20",
+      textGradient: "from-cyan-400 to-blue-400",
+    },
+    {
+      title: "Savings Rate",
+      amount: stats.savingsRate.toFixed(1) + "%",
+      change: savingsTrend.change,
+      trendLabel: sharedLabel,
+      trend: savingsTrend.trend,
+      icon: PiggyBank,
+      gradient: "from-green-500/20 to-emerald-500/20",
+      border: "border-green-500/20",
+      textGradient: "from-green-400 to-emerald-400",
+    },
+    {
+      title: "Expense-to-Income Ratio",
+      amount: stats.expenseToIncomeRatio.toFixed(1) + "%",
+      change: ratioTrend.change,
+      trendLabel: sharedLabel,
+      trend: ratioTrend.trend,
+      icon: Percent,
+      gradient: "from-orange-500/20 to-red-500/20",
+      border: "border-orange-500/20",
+      textGradient: "from-orange-400 to-red-400",
+    },
+  ];
+}
+
+/**
+ * Inner component that handles the self-fetch path (no stats prop provided).
+ * Keeping it separate avoids calling hooks conditionally in the outer component.
+ */
+function OverviewCardsSelfFetch({
+  filters,
+  preset,
+  excludedCount,
+}: {
+  filters?: TransactionFilters;
+  preset?: DateRangePreset;
+  excludedCount: number;
+}) {
   const [cards, setCards] = useState<CardData[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const stats = await getDashboardStats(filters);
+        setCards(buildCardData(stats, preset));
+      } catch (err) {
+        console.error("Failed to fetch dashboard stats:", err);
+        setError(err instanceof Error ? err.message : "Failed to load data");
+      }
+    }
+    fetchData();
+  }, [filters, preset]);
+
+  return (
+    <OverviewCardsView
+      cards={cards}
+      error={error}
+      excludedCount={excludedCount}
+    />
+  );
+}
+
+export function OverviewCards({
+  filters,
+  preset,
+  stats: statsProp,
+}: OverviewCardsProps) {
+  // The excludedCount fetch is independent of stats — always run it.
   const [excludedCount, setExcludedCount] = useState(0);
 
   useEffect(() => {
@@ -114,139 +268,36 @@ export function OverviewCards({ filters, preset }: OverviewCardsProps) {
     fetchAccountCounts();
   }, []);
 
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const stats = await getDashboardStats(filters);
+  // When the parent provides stats, derive card data directly — no effect needed.
+  if (statsProp !== undefined) {
+    const cards = statsProp ? buildCardData(statsProp, preset) : null;
+    return (
+      <OverviewCardsView
+        cards={cards}
+        error={null}
+        excludedCount={excludedCount}
+      />
+    );
+  }
 
-        const trendLabel = getTrendLabel(preset);
-        const prev = stats.previousPeriod;
+  return (
+    <OverviewCardsSelfFetch
+      filters={filters}
+      preset={preset}
+      excludedCount={excludedCount}
+    />
+  );
+}
 
-        // Helper: build change text + trend direction from a pct value
-        const makeTrend = (
-          pct: number | null
-        ): { change: string; trend: "up" | "down" | "neutral" } => {
-          if (pct === null || trendLabel === null) {
-            return { change: "—", trend: "neutral" };
-          }
-          return {
-            change: formatPercentage(pct),
-            trend: pct > 0 ? "up" : pct < 0 ? "down" : "neutral",
-          };
-        };
-
-        // Income
-        const incomePct = prev
-          ? pctChange(stats.totalIncome, prev.totalIncome)
-          : null;
-        const incomeTrend = makeTrend(incomePct);
-
-        // Expenses
-        const expensesPct = prev
-          ? pctChange(stats.totalExpenses, prev.totalExpenses)
-          : null;
-        const expensesTrend = makeTrend(expensesPct);
-
-        // Net cash flow
-        const cashFlowPct = prev
-          ? pctChange(stats.netCashFlow, prev.netCashFlow)
-          : null;
-        const cashFlowTrend = makeTrend(cashFlowPct);
-
-        // Savings rate (absolute percentage points, not pct-of-pct)
-        const savingsPct = prev
-          ? pctChange(stats.savingsRate, prev.savingsRate)
-          : null;
-        const savingsTrend = makeTrend(savingsPct);
-
-        // Expense-to-income ratio
-        const ratioPct = prev
-          ? pctChange(stats.expenseToIncomeRatio, prev.expenseToIncomeRatio)
-          : null;
-        const ratioTrend = makeTrend(ratioPct);
-
-        const sharedLabel = trendLabel ?? "—";
-
-        const cardData: CardData[] = [
-          {
-            title: "Total Balance",
-            amount: formatCurrency(stats.totalBalance),
-            // Balance is a point-in-time value — no period comparison makes sense
-            change: "—",
-            trendLabel: "current balance",
-            trend: "neutral",
-            icon: Wallet,
-            gradient: "from-blue-500/20 to-purple-500/20",
-            border: "border-blue-500/20",
-            textGradient: "from-blue-400 to-purple-400",
-          },
-          {
-            title: "Income",
-            amount: formatCurrency(stats.totalIncome),
-            change: incomeTrend.change,
-            trendLabel: sharedLabel,
-            trend: incomeTrend.trend,
-            icon: ArrowUpRight,
-            gradient: "from-emerald-500/20 to-teal-500/20",
-            border: "border-emerald-500/20",
-            textGradient: "from-emerald-400 to-teal-400",
-          },
-          {
-            title: "Expenses",
-            amount: formatCurrency(stats.totalExpenses),
-            change: expensesTrend.change,
-            trendLabel: sharedLabel,
-            trend: expensesTrend.trend,
-            icon: ArrowDownRight,
-            gradient: "from-rose-500/20 to-orange-500/20",
-            border: "border-rose-500/20",
-            textGradient: "from-rose-400 to-orange-400",
-          },
-          {
-            title: "Net Cash Flow",
-            amount: formatCurrency(stats.netCashFlow),
-            change: cashFlowTrend.change,
-            trendLabel: sharedLabel,
-            trend: cashFlowTrend.trend,
-            icon: Coins,
-            gradient: "from-cyan-500/20 to-blue-500/20",
-            border: "border-cyan-500/20",
-            textGradient: "from-cyan-400 to-blue-400",
-          },
-          {
-            title: "Savings Rate",
-            amount: stats.savingsRate.toFixed(1) + "%",
-            change: savingsTrend.change,
-            trendLabel: sharedLabel,
-            trend: savingsTrend.trend,
-            icon: PiggyBank,
-            gradient: "from-green-500/20 to-emerald-500/20",
-            border: "border-green-500/20",
-            textGradient: "from-green-400 to-emerald-400",
-          },
-          {
-            title: "Expense-to-Income Ratio",
-            amount: stats.expenseToIncomeRatio.toFixed(1) + "%",
-            change: ratioTrend.change,
-            trendLabel: sharedLabel,
-            trend: ratioTrend.trend,
-            icon: Percent,
-            gradient: "from-orange-500/20 to-red-500/20",
-            border: "border-orange-500/20",
-            textGradient: "from-orange-400 to-red-400",
-          },
-        ];
-
-        setCards(cardData);
-      } catch (err) {
-        console.error("Failed to fetch dashboard stats:", err);
-        setError(err instanceof Error ? err.message : "Failed to load data");
-      }
-    }
-
-    fetchData();
-  }, [filters, preset]);
-
+function OverviewCardsView({
+  cards,
+  error,
+  excludedCount,
+}: {
+  cards: CardData[] | null;
+  error: string | null;
+  excludedCount: number;
+}) {
   // Loading state
   if (!cards && !error) {
     return (

--- a/src/hooks/use-date-range.ts
+++ b/src/hooks/use-date-range.ts
@@ -21,6 +21,9 @@ export type DateRangePreset =
   | "last30days"
   | "thisMonth"
   | "lastMonth"
+  | "last3months"
+  | "last6months"
+  | "last12months"
   | "thisYear"
   | "lastYear"
   | "allTime"
@@ -45,6 +48,12 @@ const getPresetRange = (preset: DateRangePreset): DateRange => {
       const lastMonth = subMonths(now, 1);
       return { from: startOfMonth(lastMonth), to: endOfMonth(lastMonth) };
     }
+    case "last3months":
+      return { from: subMonths(now, 3), to: now };
+    case "last6months":
+      return { from: subMonths(now, 6), to: now };
+    case "last12months":
+      return { from: subMonths(now, 12), to: now };
     case "thisYear":
       return { from: startOfYear(now), to: endOfYear(now) };
     case "lastYear": {

--- a/src/lib/stats/calculations.ts
+++ b/src/lib/stats/calculations.ts
@@ -429,6 +429,56 @@ export function calculateDiscretionaryRatio(
   };
 }
 
+export interface MonthlyAveragesInput {
+  totalIncome: number;
+  totalExpenses: number;
+  netCashFlow: number;
+  startDate?: string; // ISO YYYY-MM-DD
+  endDate?: string; // ISO YYYY-MM-DD
+}
+
+export interface MonthlyAveragesResult {
+  avgMonthlyIncome: number;
+  avgMonthlyExpenses: number;
+  avgMonthlyNet: number;
+  monthsCount: number; // whole number of months used as divisor (min 1)
+  isPartialMonth: boolean; // true when the range spans fewer than 28 days
+}
+
+/**
+ * Calculates per-month averages for income, expenses, and net cash flow.
+ *
+ * Month-count rule (duration-based, NOT calendar+1):
+ * A "Last 3 Months" range (~91 days) must divide by 3, so we use
+ * elapsed duration / average-month-length (30.44), not calendar-boundary counting.
+ */
+export function calculateMonthlyAverages(
+  input: MonthlyAveragesInput
+): MonthlyAveragesResult {
+  const { totalIncome, totalExpenses, netCashFlow, startDate, endDate } = input;
+
+  let monthsCount: number;
+  let isPartialMonth: boolean;
+
+  if (startDate && endDate) {
+    const days = differenceInDays(parseISO(endDate), parseISO(startDate)) + 1;
+    const rawMonths = days / 30.44;
+    monthsCount = Math.max(1, Math.round(rawMonths));
+    isPartialMonth = days < 28;
+  } else {
+    monthsCount = 1;
+    isPartialMonth = false;
+  }
+
+  return {
+    avgMonthlyIncome: Math.round((totalIncome / monthsCount) * 100) / 100,
+    avgMonthlyExpenses: Math.round((totalExpenses / monthsCount) * 100) / 100,
+    avgMonthlyNet: Math.round((netCashFlow / monthsCount) * 100) / 100,
+    monthsCount,
+    isPartialMonth,
+  };
+}
+
 // --- Backward Compatibility Wrappers ---
 // These maintain compatibility with existing stats.actions.ts
 


### PR DESCRIPTION
## What & why

Adds a **Monthly Averages** section to the dashboard so the user can answer "how much do I make / spend / keep in a typical month over this period?" — e.g. *"on average over the last 3 months."* Previously the dashboard only showed period **totals**, not per-month averages.

## Changes

- **New "Monthly Averages" section** — three cards: Avg. Monthly Income, Avg. Monthly Spending, Avg. Monthly Net. Respects the active date range and account filter.
- **New date presets** — "Last 3 Months", "Last 6 Months", "Last 12 Months" (the user's literal use case wasn't selectable before).
- **Duration-based month count** — divisor = elapsed days / 30.44, rounded, min 1, so "Last 3 Months" divides by 3 (matches user expectation, not calendar-boundary counting). Ranges under 28 days show an amber "partial month" note and fall back to the period total.
- **Server-side computation** — new `DashboardStats.averages` field; pure `calculateMonthlyAverages()` helper.
- **Visual distinction** — averages cards use reduced-opacity Neo-Glass styling and a `/ month` suffix + labeled section heading so they're never confused with the totals row.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- `npx prettier --check .` — passes
- `npm run lint` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added monthly averages dashboard displaying average income, expenses, and net cash flow for the selected date range.
  * Added new date range presets: Last 3 Months, Last 6 Months, and Last 12 Months for enhanced filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->