### PR TITLE
feat(sandbox): What-If Financial Scenario Playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ logs/security/
 /playwright-report/
 /.last-run.json
 /.tmp-qa/
+/qa/

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -1,9 +1,60 @@
 # Project State: BanKing
 
-**Current Phase:** What-If Financial Sandbox — Visual QA ✅ COMPLETE
+**Current Phase:** What-If Financial Sandbox — Bug Fixes ✅ COMPLETE
 **Current Sprint:** feat/what-if-sandbox
 **Last Session:** 2026-06-07
 **Branch:** feat/what-if-sandbox
+
+---
+
+## This session changes (2026-06-07) — /sandbox four bug fixes
+
+**Summary:** Fixed four bugs in the `/sandbox` feature. All changes in `src/` only; no commits made per task scope. `npx tsc --noEmit` clean, `npm run lint` at 36 problems (all pre-existing, zero new). Three QA screenshots captured to `qa/` (gitignored).
+
+**Bug 1 — Duplicate React key crash (subscription Select)**
+
+- **Root cause:** `detectRecurring()` emits multiple `RecurringTransactionGroup` entries for the same `counterparty` (different amount clusters). `rule-card.tsx` used `key={g.counterparty}` on Select items, crashing when two groups shared the same counterparty string.
+- **Fix:** In `page.tsx`, the `recurringGroups` useMemo now deduplicates by `counterparty.trim().toLowerCase()`, merging clusters into one entry whose `averageAmount` is the SUM of all merged clusters. This ensures the full recurring monthly cost is reflected when a merchant is cancelled, and `counterparty` is now unique so the key is safe.
+- **File:** `src/app/(dashboard)/sandbox/page.tsx`
+
+**Bug 2 — ETF "Monthly contribution" slider does nothing**
+
+- **Root cause:** `computeRecurringDelta()` in `sandbox-projector.ts` did not handle `investment` rules. Only `computeInterest()` (yield) was applied, so the monthly deposit amount had no effect on the balance.
+- **Fix:** Added `investment` rule handling inside `computeRecurringDelta()` — `rule.amount` is added to the delta every month, growing the balance that `computeInterest()` then compounds on. Updated JSDoc comment. Verified: enabling an ETF rule with +€800/mo at 0% yield shows Year 1 +€9,600, Year 5 +€48,000, Year 10 +€96,000 above baseline.
+- **File:** `src/lib/stats/sandbox-projector.ts`
+
+**Bug 3 — Recurring "Monthly delta" range too small**
+
+- **Fix:** Changed recurring amount slider `min`/`max` from ±2000 to ±5000 (step 50 kept). Updated range labels to "-€5 000" / "+€5 000". Changed investment "Monthly contribution" slider `max` from 2000 to 5000 and label from "€2 000" to "€5 000".
+- **File:** `src/components/sandbox/rule-card.tsx`
+
+**Bug 4 — Light-mode contrast (cards invisible)**
+
+- **Root cause:** Hardcoded `border-white/10` / `border-white/5` and translucent `bg-card/40` / `bg-card/30` / `bg-card/20` only read well on dark backgrounds; in light mode the cards were invisible.
+- **Fix:** Replaced all `border-white/10` / `border-white/5` container borders with `border-border` (theme token). Replaced `bg-card/40` container backgrounds with `bg-card dark:bg-card/80` to stay opaque in light mode while preserving the glass effect in dark mode. Inner controls (Select trigger, Input) changed from `bg-card/50 border-white/10` to `bg-background border-border`. Empty-state "No rules yet" changed from `bg-card/20 border-white/5` to `bg-muted/30 border-border dark:bg-card/20`. SafetyNetBadge changed from `border-white/10` to `border-border dark:border-emerald-500/20`.
+- **Files:** `src/app/(dashboard)/sandbox/page.tsx`, `src/components/sandbox/rule-card.tsx`
+
+**Files Modified:**
+
+- `src/app/(dashboard)/sandbox/page.tsx` — Bug 1 dedupe + Bug 4 border/bg tokens
+- `src/lib/stats/sandbox-projector.ts` — Bug 2 investment monthly deposit
+- `src/components/sandbox/rule-card.tsx` — Bug 3 slider ranges + Bug 4 border/bg tokens
+
+**QA screenshots (gitignored `qa/`):**
+
+- `qa/bugfix-a-light-mode-cards.png` — light mode, cards visibly distinguishable with solid backgrounds and theme borders
+- `qa/bugfix-b-etf-800-0pct-yield.png` — dark mode, ETF +€800/mo contribution at 0% yield, scenario line clearly above baseline
+- `qa/bugfix-c-subscription-select-open.png` — dark mode, subscription Select open, no console errors, no duplicate-key crash
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean (no errors)
+- `npm run lint` — 36 problems, all pre-existing; zero new issues
+- QA script (`node qa/bug-fixes-qa.mjs`) — "All checks passed. Zero runtime errors."
+
+**Next actions:**
+
+- PR / merge `feat/what-if-sandbox` into main once lead reviews.
 
 ---
 

--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -1,9 +1,127 @@
 # Project State: BanKing
 
-**Current Phase:** Balance Prediction — 10-year forecast horizon ✅ COMPLETE
-**Current Sprint:** feat/balance-prediction
-**Last Session:** 2026-06-04
-**Branch:** feat/balance-prediction
+**Current Phase:** What-If Financial Sandbox — Visual QA ✅ COMPLETE
+**Current Sprint:** feat/what-if-sandbox
+**Last Session:** 2026-06-07
+**Branch:** feat/what-if-sandbox
+
+---
+
+## This session changes (2026-06-07) — Visual QA: /sandbox page
+
+**Summary:** Full Playwright headless QA of the `/sandbox` page. All 7 test cases pass after fixing two bugs in `comparison-chart.tsx`. Screenshots saved to `qa/` (gitignored). No source commits made — bugs fixed in-place per task scope.
+
+**Bugs found and fixed:**
+
+1. **`ComparisonChart` dispose crash** (`src/components/sandbox/comparison-chart.tsx`, line ~289)
+   - **Symptom:** `Runtime TypeError: Cannot read properties of null (reading 'getAttribute')` — page crashed on load in React 18 Strict Mode's double-invoke cleanup pass.
+   - **Root cause:** `useEffect` cleanup called `chartRef.current.getEchartsInstance()` where `getEchartsInstance()` throws when the echarts instance is already disposed (Strict Mode runs cleanup → remount).
+   - **Fix:** Wrapped in `try/catch`; added `isDisposed()` guard before calling `.dispose()`. Also moved ref access inside the cleanup closure (not captured at setup time).
+
+2. **`visualMap` ECharts crash on rule add/change** (`src/components/sandbox/comparison-chart.tsx`, line ~172)
+   - **Symptom:** `Runtime TypeError: Cannot read properties of undefined (reading 'coord')` — fired 8 times during QA interactions (every slider click / rule add). Stack: `getVisualGradient → LineView.render → ECharts._onframe`.
+   - **Root cause:** ECharts' `visualMap` with `dimension: 1` (y-value gradient coloring) calls `getVisualGradient` from the animation frame loop. When React state updates trigger a chart option rebuild, the internal coordinate system is transiently `undefined` while the animation frame fires, crashing `getVisualGradient`.
+   - **Fix:** Removed `visualMap` entirely. Replaced with two split series: `Scenario` (violet, `≥0` values) and `_scenarioCrimson` (crimson, `<0` values) with `connectNulls: false`. This achieves the same visual coloring without any coordinate-system dependency during rendering. Also changed `notMerge={false}` + `lazyUpdate={true}` and added a one-tick `setTimeout` debounce on the option state to prevent mid-frame option updates.
+
+**Files Modified:**
+
+- `src/components/sandbox/comparison-chart.tsx` — dispose guard + split violet/crimson series replacing visualMap + debounced option state + `notMerge={false}` / `lazyUpdate={true}`
+- `.gitignore` — added `/qa/` to ensure QA scripts and screenshots are not committed
+
+**QA tooling added (gitignored, not committed):**
+
+- `qa/sandbox-qa.mjs` — Playwright headless QA script
+- `qa/sandbox-*.png` — 6 screenshots from the test run
+
+**Test results (all PASS):**
+
+| TC  | Description                                    | Result |
+| --- | ---------------------------------------------- | ------ |
+| 1   | Load /sandbox — nav, title, badge, layout, chart, delta widget | PASS |
+| 2   | Add Recurring +€500 — scenario line rises above baseline | PASS |
+| 3   | One-Time -€200k at Yr2 — drop + crimson below zero | PASS |
+| 4   | Toggle all rules OFF — scenario snaps to baseline | PASS |
+| 5   | Delta widget (Yr1/Yr5/Yr10) + Safety-Net badge update | PASS |
+| 6   | Browser console — zero runtime errors, no React warnings | PASS |
+| 7   | Reload — localStorage persistence of rules | PASS |
+
+**Console warnings (non-critical, pre-existing):**
+
+- `Image with src "/logo-light.png" has "fill" but is missing "sizes" prop` — pre-existing Next.js image optimization warning in the layout header, unrelated to sandbox.
+
+**Visual observations:**
+
+- TC-1: Neo-Glass styling renders correctly. Violet gradient title, "Simulation Mode" badge, two-column layout, ECharts chart with dotted grey baseline and solid violet scenario line.
+- TC-2: Recurring rule card shows "+200 € / mo" slider, delta widget shows Year 1 +2,399.97 € / Year 5 +11,999.85 € / Year 10 +23,999.70 €. Violet scenario line visibly above baseline.
+- TC-3: Sharp drop at Year 2 to -€200k. Crimson red segment clearly visible below zero. Y-axis extends to accommodate the one-time expense input. Safety Net badge updates to a lower coverage value when the large expense is added.
+- TC-4: Both rule cards show 50% opacity. Chart scenario line perfectly overlaps dotted baseline. Safety Net badge restores to its baseline coverage value.
+- TC-5: Delta widget shows positive surplus at Year 1 (function of the +€200/mo input) and large negative deltas at Year 5 / Year 10 (function of the -€200k one-time input). Safety-Net badge coverage change is readable in the widget.
+- TC-7: After reload, both rules restored with correct state (slider positions, amounts). Chart renders the full crimson-drop pattern from localStorage.
+
+**Next actions:**
+
+- PR / merge `feat/what-if-sandbox` into main once lead reviews QA screenshots.
+
+---
+
+## This session changes (2026-06-07) — What-If Sandbox: Phase 2 UI
+
+**Summary:** Built the complete `/sandbox` UI — scenario manager, rule editors, 10-year comparison chart, delta widget, safety-net badge, and nav link. Consumes Phase 1 exports (`calculateSandboxPrediction`, `useScenarios`) and existing action/stat helpers. Zero new lint errors; 36 pre-existing problems unchanged. Build clean with `/sandbox` route emitted.
+
+**Files Created:**
+
+- `src/app/(dashboard)/sandbox/page.tsx` — Main "Scenario Playground" client page. On mount fetches transactions + total balance, computes `calculateMonthlyFlow`, `detectRecurring`. Uses `useScenarios()` for all scenario/rule state. Calls `calculateSandboxPrediction` via `useMemo`. Renders loading skeleton, insufficient-data onboarding state, or 12-col desktop layout (left: scenario panel col-span-4, right: visualization col-span-8). Insufficient-data message: "Not enough history yet to simulate — we need at least 3 months of data."
+- `src/components/sandbox/comparison-chart.tsx` — ECharts comparison chart. Baseline dotted grey series, scenario violet glow series with `visualMap` coloring segments crimson (≤0) / violet (>0), scenario confidence band via `_bandBase`/`_bandFill` stacked-area convention matching insights. X-axis in yearly labels (Now, Year 1 … Year 10). Responsive, disposes ECharts instance on unmount. `/* eslint-disable @typescript-eslint/no-explicit-any */` at file top (ECharts formatter callbacks).
+- `src/components/sandbox/rule-card.tsx` — Per-rule editor card. Type-specific controls: `recurring` (amount slider ±€2000 step €50, start-month slider 0–12), `onetime` (amount Input + target year slider 1–10), `subscription` (Select from detected recurring groups + savings note), `investment` (monthly contribution slider + annual yield slider 0–12%). Each card: name, enabled Switch, delete button. Calls `updateRule`/`removeRule`.
+
+**Files Modified:**
+
+- `src/components/layout/nav.tsx` — Added `{ href: "/sandbox", label: "Sandbox" }` between Transactions and Settings.
+
+**shadcn components installed:**
+
+- `slider` — `npx shadcn@latest add slider` (was missing; all others already present).
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean (no errors)
+- `npm run lint` — 36 problems, all pre-existing in unrelated files; zero new issues in created/modified files
+- `npm run build` — succeeds; `/sandbox` route emitted as static page
+
+**Next actions:**
+
+- PR / merge `feat/what-if-sandbox` into main once reviewed.
+
+---
+
+## This session changes (2026-06-07) — What-If Sandbox: Phase 1 foundation (non-UI)
+
+**Summary:** Implemented the non-UI foundation for the What-If Financial Sandbox at `/sandbox`. No page, chart, or card was built — this is the pure math engine and client-side persistence layer only.
+
+**Files Created:**
+
+- `src/lib/stats/sandbox-projector.ts` — Simulation engine. Exports `ScenarioRule`, `SandboxPoint`, `SandboxResult`, and `calculateSandboxPrediction(totalBalance, monthlyCashFlow, rules, years?, currentMonth?)`. Produces 120 monthly points (10-year default). Baseline is numerically consistent with the Insights forecast at yearly marks. Scenario layer iterates month-by-month: recurring deltas, subscription cancellations (expense added back), compound investment interest on running balance, one-time lump sums at exact target months. Spread model (`stdDev * sqrt(m)`) is identical to `calculateBalancePrediction`. All outputs rounded to cents. No I/O, no DB access.
+- `src/hooks/use-scenarios.ts` — Client hook `useScenarios()`. Manages `Record<string, Scenario>` persisted to `localStorage` key `banking:sandbox:scenarios:v1`. SSR-safe via lazy `useState` initialiser (no `useEffect` setState). Skips initial persist via `useRef` guard. Exports: `scenarios`, `activeScenarioId`, `setActiveScenarioId`, `addRule`, `updateRule`, `removeRule`, `saveAsNew`, `renameScenario`, `deleteScenario`. IDs generated with `crypto.randomUUID()`. Default scenario (`"default"`) always exists and cannot be deleted.
+
+**Files Modified:**
+
+- `src/lib/stats/calculations.ts` — Extracted the trailing-window selection logic from `calculateBalancePrediction` into a new exported helper `selectProjectionWindow(monthlyCashFlow, currentMonth, minMonths?)`. Returns `{ window, mean, stdDev } | null`. `calculateBalancePrediction` now delegates to this helper; public behaviour is unchanged. The export allows `sandbox-projector.ts` to reuse the exact same mean/stdDev derivation without copy-pasting.
+
+**Constraints respected:**
+
+- No page, chart, or card components created (Phase 2 scope).
+- No DB writes; no mutation actions called.
+- Strict TypeScript (`readonly` on all interface fields, explicit return types, no `any`).
+- Named imports, `@/` path aliases, project conventions followed throughout.
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean (no errors)
+- `npm run lint` — 36 problems, all pre-existing in unrelated files; zero new issues in changed/created files
+
+**Next actions:**
+
+- Phase 2: Build the `/sandbox` page, scenario editor UI, and projection chart consuming these exports.
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // One-time QA scripts and screenshots (gitignored, not part of the app):
+    "qa/**",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "motion": "^12.29.0",
         "next": "16.1.4",
         "next-themes": "^0.4.6",
-        "radix-ui": "^1.4.3",
+        "radix-ui": "^1.5.0",
         "react": "19.2.3",
         "react-day-picker": "^9.13.0",
         "react-dom": "19.2.3",
@@ -1216,21 +1216,21 @@
       }
     },
     "node_modules/@radix-ui/number": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
-      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+      "integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="
     },
     "node_modules/@radix-ui/react-accessible-icon": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
-      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.9.tgz",
+      "integrity": "sha512-5W9KzJz/3DeYbGJHbZv8Q6AkxMOKUmALfc+PRg9dWwJZMk6zD37Sz8sZrF7UD6CBkiJvn7dNeRzn5G7XiCMyig==",
       "dependencies": {
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/react-visually-hidden": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1248,19 +1248,19 @@
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
-      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.13.tgz",
+      "integrity": "sha512-xITxBB2p5m5tAe7M0F95kb4uAh7jSIKGlExMEm93HlW+XxZHV2eXFbPWLktd4JhRiwcnXNbO7iekcrbZy6ZCvA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collapsible": "1.1.13",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1278,16 +1278,16 @@
       }
     },
     "node_modules/@radix-ui/react-alert-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
-      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.16.tgz",
+      "integrity": "sha512-vPaIgo0mxYlvcFaM9jB2Uot9TjGXMuAPEvrc6BOLeV+I5U8s1dkIoouYaa6lmSfc5SPMo5x5djOTOTvaigdGMQ==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dialog": "1.1.16",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1304,29 +1304,12 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
-      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
+      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1344,11 +1327,11 @@
       }
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
-      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.9.tgz",
+      "integrity": "sha512-Xy+Dpxt/5n9rVTdPrNFmf8GwG1NlT1pzCF/z1MgOGZMLZWdWl+km+ZRWGQAPEhbkzSwYEsfYmTca8NhUtVxqnw==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1366,15 +1349,15 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.12.tgz",
+      "integrity": "sha512-NQCQyWC7QrDPhjMn8hUqFeU0lUrprIgm1AyMgLbzuQJibNnatdc3SSMo3/UGFu/eUkJUU1cEcKCnyhXTQzq6tA==",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1392,18 +1375,18 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
-      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.4.tgz",
+      "integrity": "sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1421,18 +1404,18 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.13.tgz",
+      "integrity": "sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1450,14 +1433,14 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1474,27 +1457,10 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1506,9 +1472,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1520,16 +1486,15 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
-      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.0.tgz",
+      "integrity": "sha512-d7CouXhAW+CGmFOqmB+IEvd3E9GcaqfgvfjCc3hfulp2pkaUCEVEGa0SN5nNWYA+IvQ6g1Pt+S5dpNn1AoY9hg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1547,24 +1512,24 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1581,27 +1546,10 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1613,15 +1561,15 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1639,17 +1587,17 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
-      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.17.tgz",
+      "integrity": "sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1667,9 +1615,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1681,13 +1629,13 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1705,38 +1653,16 @@
       }
     },
     "node_modules/@radix-ui/react-form": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
-      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.9.tgz",
+      "integrity": "sha512-eTPyThIKDacJ3mJDvYwf/PSmsEYlOyA2Qcb+aGyWwYv+P5w57VPUkMVA2XJ9z0Du2KBY1HoHQzhPV9iYL/r4hg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-label": "2.1.9",
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1754,19 +1680,19 @@
       }
     },
     "node_modules/@radix-ui/react-hover-card": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
-      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.16.tgz",
+      "integrity": "sha512-hAileDBtd6CX7nlZOarOnISQ6PP4q0e16BX51ulzdZ+7IzjL0sDTVpFdmSYrIjw6zVNsfQBao5gG6AWr3qwfvA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1784,11 +1710,11 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1801,33 +1727,11 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
-      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.9.tgz",
+      "integrity": "sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1845,28 +1749,28 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
-      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.17.tgz",
+      "integrity": "sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1883,38 +1787,21 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-menubar": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
-      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.17.tgz",
+      "integrity": "sha512-AKtZ4O782yO7qwIyq73WpulYt1IHhQ0htDb6wNcxzxnSDCcSWMVBiU9ycpcA90XzQO4IVIxIErtak6Kg/Vt0rQ==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1932,24 +1819,24 @@
       }
     },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
-      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.15.tgz",
+      "integrity": "sha512-/fS8hKCcRt4DwCGa5QIB3juRXmfYSOk4a2AEe/BDIyy7Hm+eje2Y13oUx5zejl+wFt1owrM7E8NWlbaEl5EGpg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1967,22 +1854,22 @@
       }
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
-      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.9.tgz",
+      "integrity": "sha512-fvCzA9hm7yN5xxTPJIi4VhSmH5gv+76ILsxguBK3cm3icD5BR4vW7POQmu8Zio0yh91uuouG/Kang40IbMkaSQ==",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2000,18 +1887,18 @@
       }
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
-      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.4.tgz",
+      "integrity": "sha512-qoDSkObZ9faJlsjlwyBH6ia7kq9vaJ2QwWTowT3nQpzPvUTAKesmWuGJYpd91HIoJqS+5ZPXy5uFPp+HlwdaAg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2029,25 +1916,25 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
-      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.16.tgz",
+      "integrity": "sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2064,38 +1951,21 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
-      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-rect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2113,12 +1983,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2136,12 +2006,11 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2159,11 +2028,11 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-slot": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2180,30 +2049,13 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
-      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.9.tgz",
+      "integrity": "sha512-+EOkvg1Zn1vI1+fRDfRSAiJ7BWfcDAo5ASMmbqrcLZ4s4USk2FGkoHgeb2X+CkUgo2zJMiyObwf1k44CrRWsyw==",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2221,20 +2073,20 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
-      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.0.tgz",
+      "integrity": "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2252,19 +2104,19 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz",
+      "integrity": "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2282,19 +2134,19 @@
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
-      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.11.tgz",
+      "integrity": "sha512-DS39ziOgea75U/TrXKU2/oKp0be2jrDHnzFLvahg/0iNAT1Zq16e4Uw0WXwyXvsK+mG3BRyMb7A3NRZMDuEXtQ==",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2312,31 +2164,32 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
-      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.0.tgz",
+      "integrity": "sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3",
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2349,55 +2202,16 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-separator": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
-      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.9.tgz",
+      "integrity": "sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.4"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2415,21 +2229,21 @@
       }
     },
     "node_modules/@radix-ui/react-slider": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.0.tgz",
+      "integrity": "sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw==",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2447,11 +2261,11 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2464,17 +2278,17 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
-      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.0.tgz",
+      "integrity": "sha512-GP1EZwhoZO/GGnhM1P5/2Vpm8iN8EnngyU0oezn2l78kN8tj25pyrvjIaT7azBhK615KSt+P2w39y57YV5jVkA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2492,18 +2306,18 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
-      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.14.tgz",
+      "integrity": "sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2521,22 +2335,22 @@
       }
     },
     "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
-      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.16.tgz",
+      "integrity": "sha512-WUymDDiN2DpoGudRN1aW4wF5O3BNQjZZO/5nngPoNiEVqjyOzirvZZNO0R6dC1ifucSINVaSv8JX1aq47VGgiA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2554,13 +2368,13 @@
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
-      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.11.tgz",
+      "integrity": "sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2578,17 +2392,17 @@
       }
     },
     "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
-      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.12.tgz",
+      "integrity": "sha512-TEgECgJaWGAHJJZGzNNEYTNBdIXqX7LchANycpyP7DkfjmuiSN7ISt1k/ZRGVJgVJonsgP4vwaiKMn5utrcwWQ==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-toggle": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2606,39 +2420,17 @@
       }
     },
     "node_modules/@radix-ui/react-toolbar": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
-      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.12.tgz",
+      "integrity": "sha512-4wHtJVdIgqMmEwUvxA0BYg/2JMRbt0L3+8UD8Ml/nhKkfXtiZcM8u/S15gQ5xj9YEd/0qlrm5bE805LsjQ+J8A==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-toggle-group": "1.1.11"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-separator": "1.1.9",
+        "@radix-ui/react-toggle-group": "1.1.12"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2656,22 +2448,22 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.9.tgz",
+      "integrity": "sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2688,27 +2480,10 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2720,12 +2495,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2738,11 +2513,11 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2755,11 +2530,11 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2772,12 +2547,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
-      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
-      "dependencies": {
-        "use-sync-external-store": "^1.5.0"
-      },
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2789,9 +2561,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2803,9 +2575,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
-      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2817,11 +2589,11 @@
       }
     },
     "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
-      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
       "dependencies": {
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/rect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2834,11 +2606,11 @@
       }
     },
     "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2851,11 +2623,11 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
+      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2873,9 +2645,9 @@
       }
     },
     "node_modules/@radix-ui/rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
-      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -7050,65 +6822,65 @@
       ]
     },
     "node_modules/radix-ui": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
-      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.5.0.tgz",
+      "integrity": "sha512-Nzh2HNpClgB31FBHRqt2xG8XNUfVfQRpf34hACC5PNrXTd5JdXdqOXwLs3BL+D8CNYiNQiJiT8QGr5Q4vq+00w==",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-accessible-icon": "1.1.7",
-        "@radix-ui/react-accordion": "1.2.12",
-        "@radix-ui/react-alert-dialog": "1.1.15",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-aspect-ratio": "1.1.7",
-        "@radix-ui/react-avatar": "1.1.10",
-        "@radix-ui/react-checkbox": "1.3.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-context-menu": "2.2.16",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-dropdown-menu": "2.1.16",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-form": "0.1.8",
-        "@radix-ui/react-hover-card": "1.1.15",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-menubar": "1.1.16",
-        "@radix-ui/react-navigation-menu": "1.2.14",
-        "@radix-ui/react-one-time-password-field": "0.1.8",
-        "@radix-ui/react-password-toggle-field": "0.1.3",
-        "@radix-ui/react-popover": "1.1.15",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-progress": "1.1.7",
-        "@radix-ui/react-radio-group": "1.3.8",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-scroll-area": "1.2.10",
-        "@radix-ui/react-select": "2.2.6",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-slider": "1.3.6",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-switch": "1.2.6",
-        "@radix-ui/react-tabs": "1.1.13",
-        "@radix-ui/react-toast": "1.2.15",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-toggle-group": "1.1.11",
-        "@radix-ui/react-toolbar": "1.1.11",
-        "@radix-ui/react-tooltip": "1.2.8",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-escape-keydown": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-accessible-icon": "1.1.9",
+        "@radix-ui/react-accordion": "1.2.13",
+        "@radix-ui/react-alert-dialog": "1.1.16",
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-aspect-ratio": "1.1.9",
+        "@radix-ui/react-avatar": "1.1.12",
+        "@radix-ui/react-checkbox": "1.3.4",
+        "@radix-ui/react-collapsible": "1.1.13",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context-menu": "2.3.0",
+        "@radix-ui/react-dialog": "1.1.16",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-dropdown-menu": "2.1.17",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-form": "0.1.9",
+        "@radix-ui/react-hover-card": "1.1.16",
+        "@radix-ui/react-label": "2.1.9",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-menubar": "1.1.17",
+        "@radix-ui/react-navigation-menu": "1.2.15",
+        "@radix-ui/react-one-time-password-field": "0.1.9",
+        "@radix-ui/react-password-toggle-field": "0.1.4",
+        "@radix-ui/react-popover": "1.1.16",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-progress": "1.1.9",
+        "@radix-ui/react-radio-group": "1.4.0",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-scroll-area": "1.2.11",
+        "@radix-ui/react-select": "2.3.0",
+        "@radix-ui/react-separator": "1.1.9",
+        "@radix-ui/react-slider": "1.4.0",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-switch": "1.3.0",
+        "@radix-ui/react-tabs": "1.1.14",
+        "@radix-ui/react-toast": "1.2.16",
+        "@radix-ui/react-toggle": "1.1.11",
+        "@radix-ui/react-toggle-group": "1.1.12",
+        "@radix-ui/react-toolbar": "1.1.12",
+        "@radix-ui/react-tooltip": "1.2.9",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-escape-keydown": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -7121,67 +6893,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -8292,14 +8003,6 @@
         }
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9150,846 +8853,723 @@
       "dev": true
     },
     "@radix-ui/number": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
-      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+      "integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="
     },
     "@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="
     },
     "@radix-ui/react-accessible-icon": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
-      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.9.tgz",
+      "integrity": "sha512-5W9KzJz/3DeYbGJHbZv8Q6AkxMOKUmALfc+PRg9dWwJZMk6zD37Sz8sZrF7UD6CBkiJvn7dNeRzn5G7XiCMyig==",
       "requires": {
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/react-visually-hidden": "1.2.5"
       }
     },
     "@radix-ui/react-accordion": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
-      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.13.tgz",
+      "integrity": "sha512-xITxBB2p5m5tAe7M0F95kb4uAh7jSIKGlExMEm93HlW+XxZHV2eXFbPWLktd4JhRiwcnXNbO7iekcrbZy6ZCvA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collapsible": "1.1.13",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-alert-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
-      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.16.tgz",
+      "integrity": "sha512-vPaIgo0mxYlvcFaM9jB2Uot9TjGXMuAPEvrc6BOLeV+I5U8s1dkIoouYaa6lmSfc5SPMo5x5djOTOTvaigdGMQ==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dialog": "1.1.16",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
       }
     },
     "@radix-ui/react-arrow": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
-      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
+      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-aspect-ratio": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
-      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.9.tgz",
+      "integrity": "sha512-Xy+Dpxt/5n9rVTdPrNFmf8GwG1NlT1pzCF/z1MgOGZMLZWdWl+km+ZRWGQAPEhbkzSwYEsfYmTca8NhUtVxqnw==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-avatar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.12.tgz",
+      "integrity": "sha512-NQCQyWC7QrDPhjMn8hUqFeU0lUrprIgm1AyMgLbzuQJibNnatdc3SSMo3/UGFu/eUkJUU1cEcKCnyhXTQzq6tA==",
       "requires": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-checkbox": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
-      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.4.tgz",
+      "integrity": "sha512-m3JmIOAX5ZzZ6VPjxEU2dbTOhoHi0nT5riwcDwe8idocsWf4a5DXJLDtZ6LfJwMBx7W+A2b7kp2TgPEKtaiF6A==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       }
     },
     "@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.13.tgz",
+      "integrity": "sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
       "requires": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
       }
     },
     "@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "requires": {}
     },
     "@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "requires": {}
     },
     "@radix-ui/react-context-menu": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
-      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.0.tgz",
+      "integrity": "sha512-d7CouXhAW+CGmFOqmB+IEvd3E9GcaqfgvfjCc3hfulp2pkaUCEVEGa0SN5nNWYA+IvQ6g1Pt+S5dpNn1AoY9hg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "react-remove-scroll": "^2.7.2"
       }
     },
     "@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "requires": {}
     },
     "@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
       }
     },
     "@radix-ui/react-dropdown-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
-      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.17.tgz",
+      "integrity": "sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "requires": {}
     },
     "@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
       "requires": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       }
     },
     "@radix-ui/react-form": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
-      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.9.tgz",
+      "integrity": "sha512-eTPyThIKDacJ3mJDvYwf/PSmsEYlOyA2Qcb+aGyWwYv+P5w57VPUkMVA2XJ9z0Du2KBY1HoHQzhPV9iYL/r4hg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-label": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-          "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-          "requires": {
-            "@radix-ui/react-primitive": "2.1.3"
-          }
-        }
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-label": "2.1.9",
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-hover-card": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
-      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.16.tgz",
+      "integrity": "sha512-hAileDBtd6CX7nlZOarOnISQ6PP4q0e16BX51ulzdZ+7IzjL0sDTVpFdmSYrIjw6zVNsfQBao5gG6AWr3qwfvA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "requires": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-label": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
-      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.9.tgz",
+      "integrity": "sha512-rDoTeMbCwRVcnmo7NGT9IlPo1yXmEI+xc1URP3oeewwZEV4mdTp1dYUhYbQdo4D1q2SjKVvv4N1gNY77QAQtjA==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.4"
-      },
-      "dependencies": {
-        "@radix-ui/react-primitive": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-          "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
-          "requires": {
-            "@radix-ui/react-slot": "1.2.4"
-          }
-        }
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
-      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.17.tgz",
+      "integrity": "sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "react-remove-scroll": "^2.7.2"
       }
     },
     "@radix-ui/react-menubar": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
-      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.17.tgz",
+      "integrity": "sha512-AKtZ4O782yO7qwIyq73WpulYt1IHhQ0htDb6wNcxzxnSDCcSWMVBiU9ycpcA90XzQO4IVIxIErtak6Kg/Vt0rQ==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-navigation-menu": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
-      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.15.tgz",
+      "integrity": "sha512-/fS8hKCcRt4DwCGa5QIB3juRXmfYSOk4a2AEe/BDIyy7Hm+eje2Y13oUx5zejl+wFt1owrM7E8NWlbaEl5EGpg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       }
     },
     "@radix-ui/react-one-time-password-field": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
-      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.9.tgz",
+      "integrity": "sha512-fvCzA9hm7yN5xxTPJIi4VhSmH5gv+76ILsxguBK3cm3icD5BR4vW7POQmu8Zio0yh91uuouG/Kang40IbMkaSQ==",
       "requires": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-password-toggle-field": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
-      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.4.tgz",
+      "integrity": "sha512-qoDSkObZ9faJlsjlwyBH6ia7kq9vaJ2QwWTowT3nQpzPvUTAKesmWuGJYpd91HIoJqS+5ZPXy5uFPp+HlwdaAg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1"
       }
     },
     "@radix-ui/react-popover": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
-      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.16.tgz",
+      "integrity": "sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "react-remove-scroll": "^2.7.2"
       }
     },
     "@radix-ui/react-popper": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
-      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
       "requires": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-rect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
       }
     },
     "@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "requires": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
       "requires": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "@radix-ui/react-slot": "1.2.5"
       }
     },
     "@radix-ui/react-progress": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
-      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.9.tgz",
+      "integrity": "sha512-+EOkvg1Zn1vI1+fRDfRSAiJ7BWfcDAo5ASMmbqrcLZ4s4USk2FGkoHgeb2X+CkUgo2zJMiyObwf1k44CrRWsyw==",
       "requires": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-radio-group": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
-      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.0.tgz",
+      "integrity": "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       }
     },
     "@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz",
+      "integrity": "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-scroll-area": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
-      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.11.tgz",
+      "integrity": "sha512-DS39ziOgea75U/TrXKU2/oKp0be2jrDHnzFLvahg/0iNAT1Zq16e4Uw0WXwyXvsK+mG3BRyMb7A3NRZMDuEXtQ==",
       "requires": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-select": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
-      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.0.tgz",
+      "integrity": "sha512-mENc7WpJvJcW8hlMpzfFcHcEhTvYS5JMBmi9HVC1Q00uhBwML086MHYUV8QQdQv6lcu0Wg8dzd1RB8AFADcG/g==",
       "requires": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3",
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "react-remove-scroll": "^2.7.2"
       }
     },
     "@radix-ui/react-separator": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
-      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.9.tgz",
+      "integrity": "sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.4"
-      },
-      "dependencies": {
-        "@radix-ui/react-primitive": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-          "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
-          "requires": {
-            "@radix-ui/react-slot": "1.2.4"
-          }
-        }
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/react-slider": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.0.tgz",
+      "integrity": "sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw==",
       "requires": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       }
     },
     "@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
       "requires": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       }
     },
     "@radix-ui/react-switch": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
-      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.0.tgz",
+      "integrity": "sha512-GP1EZwhoZO/GGnhM1P5/2Vpm8iN8EnngyU0oezn2l78kN8tj25pyrvjIaT7azBhK615KSt+P2w39y57YV5jVkA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
-      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.14.tgz",
+      "integrity": "sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-toast": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
-      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.16.tgz",
+      "integrity": "sha512-WUymDDiN2DpoGudRN1aW4wF5O3BNQjZZO/5nngPoNiEVqjyOzirvZZNO0R6dC1ifucSINVaSv8JX1aq47VGgiA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       }
     },
     "@radix-ui/react-toggle": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
-      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.11.tgz",
+      "integrity": "sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-toggle-group": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
-      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.12.tgz",
+      "integrity": "sha512-TEgECgJaWGAHJJZGzNNEYTNBdIXqX7LchANycpyP7DkfjmuiSN7ISt1k/ZRGVJgVJonsgP4vwaiKMn5utrcwWQ==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-toggle": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       }
     },
     "@radix-ui/react-toolbar": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
-      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.12.tgz",
+      "integrity": "sha512-4wHtJVdIgqMmEwUvxA0BYg/2JMRbt0L3+8UD8Ml/nhKkfXtiZcM8u/S15gQ5xj9YEd/0qlrm5bE805LsjQ+J8A==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-toggle-group": "1.1.11"
-      },
-      "dependencies": {
-        "@radix-ui/react-separator": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-          "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-          "requires": {
-            "@radix-ui/react-primitive": "2.1.3"
-          }
-        }
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-separator": "1.1.9",
+        "@radix-ui/react-toggle-group": "1.1.12"
       }
     },
     "@radix-ui/react-tooltip": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.9.tgz",
+      "integrity": "sha512-u6F9MmTtBSLkiXNVDrtB/yPCZarM9smNswC24YYLV/M+bth6J3Gs3vlJezEoFwKZvPvxhCpUYdUnOsNG/0XOlA==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-visually-hidden": "1.2.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       }
     },
     "@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "requires": {}
     },
     "@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "requires": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "requires": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
       "requires": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       }
     },
     "@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
-      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
-      "requires": {
-        "use-sync-external-store": "^1.5.0"
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "requires": {}
     },
     "@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "requires": {}
     },
     "@radix-ui/react-use-previous": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
-      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
       "requires": {}
     },
     "@radix-ui/react-use-rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
-      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
       "requires": {
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/rect": "1.1.2"
       }
     },
     "@radix-ui/react-use-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
       "requires": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       }
     },
     "@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
+      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
       "requires": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.5"
       }
     },
     "@radix-ui/rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
-      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA=="
     },
     "@rtsao/scc": {
       "version": "1.1.0",
@@ -12666,91 +12246,65 @@
       "dev": true
     },
     "radix-ui": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
-      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.5.0.tgz",
+      "integrity": "sha512-Nzh2HNpClgB31FBHRqt2xG8XNUfVfQRpf34hACC5PNrXTd5JdXdqOXwLs3BL+D8CNYiNQiJiT8QGr5Q4vq+00w==",
       "requires": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-accessible-icon": "1.1.7",
-        "@radix-ui/react-accordion": "1.2.12",
-        "@radix-ui/react-alert-dialog": "1.1.15",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-aspect-ratio": "1.1.7",
-        "@radix-ui/react-avatar": "1.1.10",
-        "@radix-ui/react-checkbox": "1.3.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-context-menu": "2.2.16",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-dropdown-menu": "2.1.16",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-form": "0.1.8",
-        "@radix-ui/react-hover-card": "1.1.15",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-menubar": "1.1.16",
-        "@radix-ui/react-navigation-menu": "1.2.14",
-        "@radix-ui/react-one-time-password-field": "0.1.8",
-        "@radix-ui/react-password-toggle-field": "0.1.3",
-        "@radix-ui/react-popover": "1.1.15",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-progress": "1.1.7",
-        "@radix-ui/react-radio-group": "1.3.8",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-scroll-area": "1.2.10",
-        "@radix-ui/react-select": "2.2.6",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-slider": "1.3.6",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-switch": "1.2.6",
-        "@radix-ui/react-tabs": "1.1.13",
-        "@radix-ui/react-toast": "1.2.15",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-toggle-group": "1.1.11",
-        "@radix-ui/react-toolbar": "1.1.11",
-        "@radix-ui/react-tooltip": "1.2.8",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-escape-keydown": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
-      },
-      "dependencies": {
-        "@radix-ui/react-label": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-          "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-          "requires": {
-            "@radix-ui/react-primitive": "2.1.3"
-          }
-        },
-        "@radix-ui/react-separator": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-          "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-          "requires": {
-            "@radix-ui/react-primitive": "2.1.3"
-          }
-        },
-        "@radix-ui/react-slot": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-          "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-          "requires": {
-            "@radix-ui/react-compose-refs": "1.1.2"
-          }
-        }
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-accessible-icon": "1.1.9",
+        "@radix-ui/react-accordion": "1.2.13",
+        "@radix-ui/react-alert-dialog": "1.1.16",
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-aspect-ratio": "1.1.9",
+        "@radix-ui/react-avatar": "1.1.12",
+        "@radix-ui/react-checkbox": "1.3.4",
+        "@radix-ui/react-collapsible": "1.1.13",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context-menu": "2.3.0",
+        "@radix-ui/react-dialog": "1.1.16",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-dropdown-menu": "2.1.17",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-form": "0.1.9",
+        "@radix-ui/react-hover-card": "1.1.16",
+        "@radix-ui/react-label": "2.1.9",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-menubar": "1.1.17",
+        "@radix-ui/react-navigation-menu": "1.2.15",
+        "@radix-ui/react-one-time-password-field": "0.1.9",
+        "@radix-ui/react-password-toggle-field": "0.1.4",
+        "@radix-ui/react-popover": "1.1.16",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-progress": "1.1.9",
+        "@radix-ui/react-radio-group": "1.4.0",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-scroll-area": "1.2.11",
+        "@radix-ui/react-select": "2.3.0",
+        "@radix-ui/react-separator": "1.1.9",
+        "@radix-ui/react-slider": "1.4.0",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-switch": "1.3.0",
+        "@radix-ui/react-tabs": "1.1.14",
+        "@radix-ui/react-toast": "1.2.16",
+        "@radix-ui/react-toggle": "1.1.11",
+        "@radix-ui/react-toggle-group": "1.1.12",
+        "@radix-ui/react-toolbar": "1.1.12",
+        "@radix-ui/react-tooltip": "1.2.9",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-escape-keydown": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
       }
     },
     "react": {
@@ -13473,12 +13027,6 @@
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
-    },
-    "use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "requires": {}
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "motion": "^12.29.0",
     "next": "16.1.4",
     "next-themes": "^0.4.6",
-    "radix-ui": "^1.4.3",
+    "radix-ui": "^1.5.0",
     "react": "19.2.3",
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",

--- a/src/app/(dashboard)/sandbox/page.tsx
+++ b/src/app/(dashboard)/sandbox/page.tsx
@@ -278,15 +278,15 @@ function ScenarioPanel({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="border-border bg-background w-full justify-between"
+              className="w-full min-w-0 justify-between bg-card/50 border-white/10 backdrop-blur-xl dark:border-white/5 hover:bg-card/70 hover:border-primary/20 transition-all duration-200"
             >
-              <span className="truncate">
+              <span className="min-w-0 truncate">
                 {activeScenario?.name ?? "Default"}
               </span>
               <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-56">
+          <DropdownMenuContent className="w-56 bg-card/95 border-white/10 backdrop-blur-xl dark:border-white/5 shadow-primary/5 shadow-xl">
             {scenarioList.map((s) => (
               <DropdownMenuItem
                 key={s.id}

--- a/src/app/(dashboard)/sandbox/page.tsx
+++ b/src/app/(dashboard)/sandbox/page.tsx
@@ -1,0 +1,713 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { FlaskConical, Plus, Shield, Pencil, Save, Trash2, ChevronDown } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import { getTransactions } from "@/actions/transactions.actions";
+import { getTotalBalance } from "@/actions/accounts.actions";
+
+import {
+  calculateMonthlyFlow,
+  calculateEmergencyFund,
+} from "@/lib/stats/calculations";
+import { detectRecurring } from "@/lib/stats/categories";
+import {
+  calculateSandboxPrediction,
+  type SandboxPoint,
+} from "@/lib/stats/sandbox-projector";
+import { useScenarios } from "@/hooks/use-scenarios";
+
+import { ComparisonChart } from "@/components/sandbox/comparison-chart";
+import { RuleCard } from "@/components/sandbox/rule-card";
+
+import type { UnifiedTransaction } from "@/lib/banking/types";
+import type { RecurringTransactionGroup } from "@/lib/stats/categories";
+import type { ScenarioRule } from "@/lib/stats/sandbox-projector";
+
+const MotionCard = motion.create(Card);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+function deltaClass(value: number): string {
+  if (value > 0) return "text-emerald-400";
+  if (value < 0) return "text-rose-400";
+  return "text-muted-foreground";
+}
+
+function deltaPrefix(value: number): string {
+  return value > 0 ? "+" : "";
+}
+
+// ---------------------------------------------------------------------------
+// Delta widget — scenario vs baseline at Yr 1 / 5 / 10
+// ---------------------------------------------------------------------------
+
+interface DeltaWidgetProps {
+  readonly points: SandboxPoint[];
+}
+
+function DeltaWidget({ points }: DeltaWidgetProps): React.JSX.Element {
+  const milestones = [
+    { label: "Year 1", month: 12 },
+    { label: "Year 5", month: 60 },
+    { label: "Year 10", month: 120 },
+  ];
+
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {milestones.map(({ label, month }) => {
+        const pt = points.find((p) => p.month === month);
+        const delta = pt ? pt.scenario - pt.baseline : null;
+
+        return (
+          <div
+            key={label}
+            className="bg-card/30 flex flex-col items-center gap-1 rounded-xl border border-white/10 p-3 text-center"
+          >
+            <p className="text-muted-foreground text-xs font-medium">{label}</p>
+            {delta !== null ? (
+              <>
+                <p
+                  className={cn(
+                    "text-base font-bold tabular-nums",
+                    deltaClass(delta)
+                  )}
+                >
+                  {deltaPrefix(delta)}
+                  {formatCurrency(delta)}
+                </p>
+                <p className="text-muted-foreground/60 text-xs">vs baseline</p>
+              </>
+            ) : (
+              <p className="text-muted-foreground text-sm">—</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Safety-Net badge
+// ---------------------------------------------------------------------------
+
+interface SafetyNetBadgeProps {
+  readonly transactions: UnifiedTransaction[];
+  readonly baselineBalance: number;
+  readonly scenarioBalance: number;
+}
+
+function SafetyNetBadge({
+  transactions,
+  baselineBalance,
+  scenarioBalance,
+}: SafetyNetBadgeProps): React.JSX.Element {
+  const baselineFund = calculateEmergencyFund(baselineBalance, transactions);
+  const scenarioFund = calculateEmergencyFund(scenarioBalance, transactions);
+
+  const diff = scenarioFund.months - baselineFund.months;
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-emerald-500/5 p-3">
+      <Shield className="h-5 w-5 shrink-0 text-emerald-400" />
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="text-foreground font-semibold">Safety Net</p>
+        <p className="text-muted-foreground text-xs">
+          Emergency fund moves from{" "}
+          <span className="font-medium">
+            {baselineFund.months.toFixed(1)} mo
+          </span>{" "}
+          to{" "}
+          <span
+            className={cn("font-medium", deltaClass(diff))}
+          >
+            {scenarioFund.months.toFixed(1)} mo
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario selector + actions panel (left column)
+// ---------------------------------------------------------------------------
+
+interface ScenarioPanelProps {
+  scenarios: ReturnType<typeof useScenarios>["scenarios"];
+  activeScenarioId: string;
+  setActiveScenarioId: (id: string) => void;
+  saveAsNew: (name: string) => void;
+  renameScenario: (id: string, name: string) => void;
+  deleteScenario: (id: string) => void;
+  addRule: (rule: Omit<ScenarioRule, "id">) => void;
+  updateRule: (id: string, patch: Partial<Omit<ScenarioRule, "id">>) => void;
+  removeRule: (id: string) => void;
+  rules: ScenarioRule[];
+  recurringGroups: RecurringTransactionGroup[];
+}
+
+function ScenarioPanel({
+  scenarios,
+  activeScenarioId,
+  setActiveScenarioId,
+  saveAsNew,
+  renameScenario,
+  deleteScenario,
+  addRule,
+  updateRule,
+  removeRule,
+  rules,
+  recurringGroups,
+}: ScenarioPanelProps): React.JSX.Element {
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [savingNew, setSavingNew] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  const activeScenario = scenarios[activeScenarioId];
+  const scenarioList = Object.values(scenarios);
+  const isDefault = activeScenarioId === "default";
+
+  const handleRenameStart = (): void => {
+    setRenameValue(activeScenario?.name ?? "");
+    setRenaming(true);
+  };
+
+  const handleRenameConfirm = (): void => {
+    if (renameValue.trim()) {
+      renameScenario(activeScenarioId, renameValue.trim());
+    }
+    setRenaming(false);
+  };
+
+  const handleSaveNew = (): void => {
+    if (newName.trim()) {
+      saveAsNew(newName.trim());
+      setNewName("");
+      setSavingNew(false);
+    }
+  };
+
+  const handleDelete = (): void => {
+    deleteScenario(activeScenarioId);
+  };
+
+  // Default rule templates
+  const handleAddRecurring = (): void => {
+    addRule({
+      type: "recurring",
+      name: "New monthly income",
+      enabled: true,
+      amount: 200,
+      startMonthOffset: 0,
+    });
+  };
+
+  const handleAddOnetime = (): void => {
+    addRule({
+      type: "onetime",
+      name: "One-time expense",
+      enabled: true,
+      amount: -5000,
+      startMonthOffset: 0,
+      targetYear: 2,
+    });
+  };
+
+  const handleAddSubscription = (): void => {
+    const firstGroup = recurringGroups[0];
+    addRule({
+      type: "subscription",
+      name: firstGroup
+        ? `Cancel: ${firstGroup.counterparty}`
+        : "Cancel subscription",
+      enabled: true,
+      amount: firstGroup ? Math.abs(firstGroup.averageAmount) : 15,
+      startMonthOffset: 0,
+      subscriptionName: firstGroup?.counterparty ?? "",
+    });
+  };
+
+  const handleAddInvestment = (): void => {
+    addRule({
+      type: "investment",
+      name: "ETF investment",
+      enabled: true,
+      amount: 300,
+      startMonthOffset: 0,
+      annualRate: 0.07,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Scenario selector */}
+      <div className="bg-card/40 rounded-xl border border-white/10 p-4 backdrop-blur-xl">
+        <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+          Active Scenario
+        </p>
+
+        {/* Scenario dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="border-white/10 bg-card/50 w-full justify-between"
+            >
+              <span className="truncate">
+                {activeScenario?.name ?? "Default"}
+              </span>
+              <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56">
+            {scenarioList.map((s) => (
+              <DropdownMenuItem
+                key={s.id}
+                onClick={() => setActiveScenarioId(s.id)}
+                className={cn(
+                  s.id === activeScenarioId && "bg-accent"
+                )}
+              >
+                {s.name}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Rename inline */}
+        {renaming ? (
+          <div className="mt-3 flex gap-2">
+            <Input
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              className="border-white/10 bg-card/50 h-8 flex-1 text-sm"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRenameConfirm();
+                if (e.key === "Escape") setRenaming(false);
+              }}
+              autoFocus
+            />
+            <Button size="sm" onClick={handleRenameConfirm}>
+              Save
+            </Button>
+          </div>
+        ) : null}
+
+        {/* Save as new inline */}
+        {savingNew ? (
+          <div className="mt-3 flex gap-2">
+            <Input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="Scenario name…"
+              className="border-white/10 bg-card/50 h-8 flex-1 text-sm"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSaveNew();
+                if (e.key === "Escape") setSavingNew(false);
+              }}
+              autoFocus
+            />
+            <Button size="sm" onClick={handleSaveNew}>
+              Save
+            </Button>
+          </div>
+        ) : null}
+
+        {/* Action buttons */}
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-white/10 gap-1.5"
+            onClick={handleRenameStart}
+          >
+            <Pencil className="h-3 w-3" />
+            Rename
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-white/10 gap-1.5"
+            onClick={() => setSavingNew(true)}
+          >
+            <Save className="h-3 w-3" />
+            Save As New
+          </Button>
+          {!isDefault && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-destructive/40 text-destructive hover:bg-destructive/10 gap-1.5"
+              onClick={handleDelete}
+            >
+              <Trash2 className="h-3 w-3" />
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Add rule buttons */}
+      <div className="bg-card/40 rounded-xl border border-white/10 p-4 backdrop-blur-xl">
+        <p className="text-muted-foreground mb-3 text-xs font-medium uppercase tracking-wide">
+          Add Rule
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-blue-500/30 bg-blue-500/5 text-blue-400 hover:bg-blue-500/15 gap-1.5"
+            onClick={handleAddRecurring}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Recurring
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-amber-500/30 bg-amber-500/5 text-amber-400 hover:bg-amber-500/15 gap-1.5"
+            onClick={handleAddOnetime}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            One-Time
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-emerald-500/30 bg-emerald-500/5 text-emerald-400 hover:bg-emerald-500/15 gap-1.5"
+            onClick={handleAddSubscription}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Cut Sub
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-violet-500/30 bg-violet-500/5 text-violet-400 hover:bg-violet-500/15 gap-1.5"
+            onClick={handleAddInvestment}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            ETF Yield
+          </Button>
+        </div>
+      </div>
+
+      {/* Rules list */}
+      {rules.length > 0 ? (
+        <div className="flex max-h-[520px] flex-col gap-3 overflow-y-auto pr-1">
+          {rules.map((rule) => (
+            <RuleCard
+              key={rule.id}
+              rule={rule}
+              recurringGroups={recurringGroups}
+              onUpdate={updateRule}
+              onRemove={removeRule}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="bg-card/20 flex flex-col items-center justify-center gap-2 rounded-xl border border-white/5 py-10 text-center">
+          <FlaskConical className="text-muted-foreground/40 h-8 w-8" />
+          <p className="text-muted-foreground text-sm">No rules yet</p>
+          <p className="text-muted-foreground/60 text-xs">
+            Add a rule above to start simulating
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function SandboxPage(): React.JSX.Element {
+  const [transactions, setTransactions] = useState<UnifiedTransaction[]>([]);
+  const [totalBalance, setTotalBalance] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    scenarios,
+    activeScenarioId,
+    setActiveScenarioId,
+    addRule,
+    updateRule,
+    removeRule,
+    saveAsNew,
+    renameScenario,
+    deleteScenario,
+  } = useScenarios();
+
+  // Load data on mount
+  useEffect(() => {
+    async function loadData(): Promise<void> {
+      try {
+        setLoading(true);
+        const [txData, balanceData] = await Promise.all([
+          getTransactions(undefined, { excludeInternal: true }),
+          getTotalBalance(),
+        ]);
+        setTransactions(txData);
+        setTotalBalance(balanceData);
+      } catch (err) {
+        console.error("Failed to load sandbox data:", err);
+        setError(
+          err instanceof Error ? err.message : "Failed to load data"
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, []);
+
+  // Derived data
+  const monthlyCashFlow = useMemo(
+    () => calculateMonthlyFlow(transactions),
+    [transactions]
+  );
+
+  const recurringGroups = useMemo(
+    () => detectRecurring(transactions),
+    [transactions]
+  );
+
+  // Active scenario rules
+  const rules = useMemo(
+    () => scenarios[activeScenarioId]?.rules ?? [],
+    [scenarios, activeScenarioId]
+  );
+
+  // Sandbox prediction (memoized)
+  const sandboxResult = useMemo(
+    () =>
+      calculateSandboxPrediction(totalBalance, monthlyCashFlow, rules),
+    [totalBalance, monthlyCashFlow, rules]
+  );
+
+  // End-state balances for Safety-Net badge
+  const finalPoints =
+    sandboxResult.status === "ok"
+      ? sandboxResult.points[sandboxResult.points.length - 1]
+      : null;
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-12 w-72" />
+          <Skeleton className="h-5 w-96" />
+        </div>
+        <div className="grid gap-6 lg:grid-cols-12">
+          <div className="space-y-4 lg:col-span-4">
+            <Skeleton className="h-48 w-full" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+          <div className="space-y-4 lg:col-span-8">
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-80 w-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <Card className="border-rose-500/20">
+          <CardContent className="flex items-center justify-center p-12">
+            <div className="text-center">
+              <p className="text-lg font-semibold text-rose-400">
+                Failed to load sandbox data
+              </p>
+              <p className="text-muted-foreground mt-2 text-sm">{error}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 pb-12">
+      {/* Page header */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <h1
+            className="text-4xl font-bold tracking-tight"
+            style={{
+              background:
+                "linear-gradient(135deg, rgba(139,92,246,1) 0%, rgba(167,139,250,1) 50%, rgba(196,181,253,0.7) 100%)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+              filter: "drop-shadow(0 0 24px rgba(139,92,246,0.35))",
+            }}
+          >
+            Scenario Playground
+          </h1>
+          <Badge className="border-violet-500/30 bg-violet-500/15 px-2.5 py-1 text-xs font-semibold text-violet-400">
+            Simulation Mode
+          </Badge>
+        </div>
+        <p className="text-muted-foreground">
+          Model financial what-ifs and see how they affect your balance over
+          time. Nothing here changes your real data.
+        </p>
+      </div>
+
+      {/* Insufficient data state */}
+      {sandboxResult.status === "insufficient-data" ? (
+        <MotionCard
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="relative overflow-hidden border-violet-500/20"
+        >
+          <div className="absolute inset-0 bg-gradient-to-br from-violet-500/5 via-transparent to-indigo-500/5 opacity-50" />
+          <CardContent className="relative z-10 flex items-center justify-between gap-6 p-8">
+            <div>
+              <p className="text-3xl font-bold text-violet-400/60">—</p>
+              <p className="text-foreground mt-2 font-semibold">
+                Not enough history yet to simulate
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                We need at least 3 months of data to run a projection. Keep
+                tracking and check back soon.
+              </p>
+            </div>
+            <FlaskConical className="h-12 w-12 shrink-0 text-violet-400/30" />
+          </CardContent>
+        </MotionCard>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-12">
+          {/* ── LEFT: Scenario manager ── */}
+          <MotionCard
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.05 }}
+            className="border-primary/10 relative overflow-hidden lg:col-span-4"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-violet-500/5 via-transparent to-indigo-500/5 opacity-40" />
+            <CardHeader className="relative z-10 pb-3">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <FlaskConical className="h-4 w-4 text-violet-400" />
+                Scenarios
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="relative z-10">
+              <ScenarioPanel
+                scenarios={scenarios}
+                activeScenarioId={activeScenarioId}
+                setActiveScenarioId={setActiveScenarioId}
+                saveAsNew={saveAsNew}
+                renameScenario={renameScenario}
+                deleteScenario={deleteScenario}
+                addRule={addRule}
+                updateRule={updateRule}
+                removeRule={removeRule}
+                rules={rules}
+                recurringGroups={recurringGroups}
+              />
+            </CardContent>
+          </MotionCard>
+
+          {/* ── RIGHT: Visualization ── */}
+          <div className="flex flex-col gap-4 lg:col-span-8">
+            {/* Comparative Delta widget */}
+            <MotionCard
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 }}
+              className="border-primary/10 relative overflow-hidden"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-violet-500/5 via-transparent to-indigo-500/5 opacity-40" />
+              <CardHeader className="relative z-10 pb-2">
+                <CardTitle className="text-sm font-semibold text-violet-300">
+                  Scenario vs Baseline
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="relative z-10">
+                {sandboxResult.status === "ok" && (
+                  <DeltaWidget points={sandboxResult.points} />
+                )}
+              </CardContent>
+            </MotionCard>
+
+            {/* Comparison chart */}
+            <MotionCard
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.15 }}
+              className="border-primary/10 relative overflow-hidden"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-violet-500/5 via-transparent to-indigo-500/5 opacity-40" />
+              <CardHeader className="relative z-10 pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  10-Year Projection
+                </CardTitle>
+                <p className="text-muted-foreground/70 text-xs">
+                  Dotted grey = baseline &nbsp;·&nbsp; Solid violet = scenario
+                </p>
+              </CardHeader>
+              <CardContent className="relative z-10">
+                {sandboxResult.status === "ok" && (
+                  <ComparisonChart points={sandboxResult.points} />
+                )}
+              </CardContent>
+            </MotionCard>
+
+            {/* Safety-Net badge */}
+            {finalPoints && (
+              <MotionCard
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+                className="border-primary/10 relative overflow-hidden"
+              >
+                <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 via-transparent to-teal-500/5 opacity-40" />
+                <CardContent className="relative z-10 p-4">
+                  <SafetyNetBadge
+                    transactions={transactions}
+                    baselineBalance={finalPoints.baseline}
+                    scenarioBalance={finalPoints.scenario}
+                  />
+                </CardContent>
+              </MotionCard>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/sandbox/page.tsx
+++ b/src/app/(dashboard)/sandbox/page.tsx
@@ -86,7 +86,7 @@ function DeltaWidget({ points }: DeltaWidgetProps): React.JSX.Element {
         return (
           <div
             key={label}
-            className="bg-card/30 flex flex-col items-center gap-1 rounded-xl border border-white/10 p-3 text-center"
+            className="bg-card flex flex-col items-center gap-1 rounded-xl border border-border p-3 text-center dark:bg-card/80"
           >
             <p className="text-muted-foreground text-xs font-medium">{label}</p>
             {delta !== null ? (
@@ -133,7 +133,7 @@ function SafetyNetBadge({
   const diff = scenarioFund.months - baselineFund.months;
 
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-emerald-500/5 p-3">
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-emerald-500/5 p-3 dark:border-emerald-500/20">
       <Shield className="h-5 w-5 shrink-0 text-emerald-400" />
       <div className="min-w-0 flex-1 text-sm">
         <p className="text-foreground font-semibold">Safety Net</p>
@@ -268,7 +268,7 @@ function ScenarioPanel({
   return (
     <div className="flex flex-col gap-4">
       {/* Scenario selector */}
-      <div className="bg-card/40 rounded-xl border border-white/10 p-4 backdrop-blur-xl">
+      <div className="bg-card rounded-xl border border-border p-4 backdrop-blur-xl dark:bg-card/80">
         <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
           Active Scenario
         </p>
@@ -278,7 +278,7 @@ function ScenarioPanel({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="border-white/10 bg-card/50 w-full justify-between"
+              className="border-border bg-background w-full justify-between"
             >
               <span className="truncate">
                 {activeScenario?.name ?? "Default"}
@@ -307,7 +307,7 @@ function ScenarioPanel({
             <Input
               value={renameValue}
               onChange={(e) => setRenameValue(e.target.value)}
-              className="border-white/10 bg-card/50 h-8 flex-1 text-sm"
+              className="border-border bg-background h-8 flex-1 text-sm"
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleRenameConfirm();
                 if (e.key === "Escape") setRenaming(false);
@@ -327,7 +327,7 @@ function ScenarioPanel({
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               placeholder="Scenario name…"
-              className="border-white/10 bg-card/50 h-8 flex-1 text-sm"
+              className="border-border bg-background h-8 flex-1 text-sm"
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleSaveNew();
                 if (e.key === "Escape") setSavingNew(false);
@@ -345,7 +345,7 @@ function ScenarioPanel({
           <Button
             variant="outline"
             size="sm"
-            className="border-white/10 gap-1.5"
+            className="border-border gap-1.5"
             onClick={handleRenameStart}
           >
             <Pencil className="h-3 w-3" />
@@ -354,7 +354,7 @@ function ScenarioPanel({
           <Button
             variant="outline"
             size="sm"
-            className="border-white/10 gap-1.5"
+            className="border-border gap-1.5"
             onClick={() => setSavingNew(true)}
           >
             <Save className="h-3 w-3" />
@@ -375,7 +375,7 @@ function ScenarioPanel({
       </div>
 
       {/* Add rule buttons */}
-      <div className="bg-card/40 rounded-xl border border-white/10 p-4 backdrop-blur-xl">
+      <div className="bg-card rounded-xl border border-border p-4 backdrop-blur-xl dark:bg-card/80">
         <p className="text-muted-foreground mb-3 text-xs font-medium uppercase tracking-wide">
           Add Rule
         </p>
@@ -433,7 +433,7 @@ function ScenarioPanel({
           ))}
         </div>
       ) : (
-        <div className="bg-card/20 flex flex-col items-center justify-center gap-2 rounded-xl border border-white/5 py-10 text-center">
+        <div className="bg-muted/30 flex flex-col items-center justify-center gap-2 rounded-xl border border-border py-10 text-center dark:bg-card/20">
           <FlaskConical className="text-muted-foreground/40 h-8 w-8" />
           <p className="text-muted-foreground text-sm">No rules yet</p>
           <p className="text-muted-foreground/60 text-xs">
@@ -496,10 +496,31 @@ export default function SandboxPage(): React.JSX.Element {
     [transactions]
   );
 
-  const recurringGroups = useMemo(
-    () => detectRecurring(transactions),
-    [transactions]
-  );
+  // Dedupe recurring groups by counterparty — detectRecurring() can emit
+  // multiple clusters for the same merchant (different amount tiers). Merge
+  // them into one entry whose averageAmount is the SUM of all clusters so
+  // that cancelling a merchant reflects its full recurring monthly cost.
+  // The merged counterparty name comes from the first (highest-frequency)
+  // cluster, preserving original casing.
+  const recurringGroups = useMemo((): RecurringTransactionGroup[] => {
+    const raw = detectRecurring(transactions);
+    const merged = new Map<string, RecurringTransactionGroup>();
+    for (const group of raw) {
+      const key = group.counterparty.trim().toLowerCase();
+      const existing = merged.get(key);
+      if (existing) {
+        // Merge: sum averageAmount, concatenate transactions list.
+        merged.set(key, {
+          ...existing,
+          averageAmount: existing.averageAmount + group.averageAmount,
+          transactions: [...existing.transactions, ...group.transactions],
+        });
+      } else {
+        merged.set(key, group);
+      }
+    }
+    return Array.from(merged.values());
+  }, [transactions]);
 
   // Active scenario rules
   const rules = useMemo(

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -11,6 +11,7 @@ export function Nav() {
     { href: "/", label: "Dashboard" },
     { href: "/insights", label: "Insights" },
     { href: "/transactions", label: "Transactions" },
+    { href: "/sandbox", label: "Sandbox" },
     { href: "/settings", label: "Settings" },
   ];
 

--- a/src/components/sandbox/comparison-chart.tsx
+++ b/src/components/sandbox/comparison-chart.tsx
@@ -1,0 +1,366 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import ReactECharts from "echarts-for-react";
+import type { EChartsOption } from "echarts";
+
+import type { SandboxPoint } from "@/lib/stats/sandbox-projector";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface ComparisonChartProps {
+  readonly points: SandboxPoint[];
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ComparisonChart({ points }: ComparisonChartProps): React.JSX.Element {
+  const { resolvedTheme } = useTheme();
+  const chartRef = useRef<ReactECharts | null>(null);
+
+  const isDark = resolvedTheme === "dark";
+  const textColor = isDark ? "rgba(241,245,249,0.9)" : "rgba(30,41,59,0.8)";
+  const gridColor = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
+  const bandTopAlpha = isDark ? 0.14 : 0.08;
+  const bandBotAlpha = isDark ? 0.03 : 0.02;
+
+  const option = useMemo((): EChartsOption => {
+    // Build x-axis labels: year marks at 0, 1, 2, … 10
+    const lastPoint = points[points.length - 1];
+    const maxYear = lastPoint ? Math.ceil(lastPoint.month / 12) : 10;
+    const xLabels: string[] = [];
+    for (let y = 0; y <= maxYear; y++) {
+      xLabels.push(y === 0 ? "Now" : `Year ${y}`);
+    }
+
+    // For each point map month → yearly index for chart x-position (0-based index)
+    // We need data as [xIndex, value] pairs — use scatter/line with numeric x instead.
+    // Simpler: use yearly category x-axis, sample points at yearly marks + month 0 anchor.
+
+    // Collect yearly marks (month 0 = now, month 12 = Yr 1, …)
+    const yearlyIndices = [0, ...Array.from({ length: maxYear }, (_, i) => i + 1)];
+
+    // Build arrays anchored at month=0 (current balance = points[0].baseline - meanNet)
+    // We use points directly for years 1..N (month 12, 24, …)
+    const yearlyPoints = yearlyIndices.slice(1).map((yr) => {
+      const targetMonth = yr * 12;
+      return points.find((p) => p.month === targetMonth) ?? null;
+    });
+
+    // Projected line (scenario): anchor at first point baseline as "now"
+    const scenarioLine = [
+      points[0]?.baseline ?? 0, // "now" anchor = baseline month 0
+      ...yearlyPoints.map((p) => p?.scenario ?? null),
+    ];
+
+    // Split scenario into violet (≥0) and crimson (<0) segments to avoid
+    // ECharts visualMap getVisualGradient crash (coord undefined during
+    // animation-frame updates). Each array keeps the real value where the
+    // condition holds and null elsewhere; ECharts connects adjacent non-null
+    // points so the two series together look like one coloured line.
+    const scenarioViolet = scenarioLine.map((v, i) => {
+      if (v === null) return null;
+      // Always show the "now" anchor (index 0) in violet
+      if (i === 0) return v;
+      // Show in violet when ≥0, or as a bridge point when transitioning
+      const prev = scenarioLine[i - 1];
+      const next = scenarioLine[i + 1] ?? null;
+      if (v >= 0) return v;
+      // Keep the last positive point and first negative point visible so the
+      // crossing is drawn — use null to break the line in the negative region.
+      if ((prev !== null && prev >= 0) || (next !== null && next >= 0)) return v;
+      return null;
+    });
+    const scenarioCrimson = scenarioLine.map((v, i) => {
+      if (v === null) return null;
+      if (i === 0) return null; // anchor always in violet
+      if (v < 0) return v;
+      // Bridge: include the last positive-to-negative crossover point
+      const next = scenarioLine[i + 1] ?? null;
+      if (next !== null && next < 0) return v;
+      return null;
+    });
+
+    // Baseline dotted line
+    const baselineLine = [
+      points[0]?.baseline ?? 0,
+      ...yearlyPoints.map((p) => p?.baseline ?? null),
+    ];
+
+    // Scenario confidence band (stacked area)
+    const bandBaseValues = [
+      points[0]?.baseline ?? 0,
+      ...yearlyPoints.map((p) => (p ? p.scenarioLower : null)),
+    ];
+    const bandFillValues = [
+      0,
+      ...yearlyPoints.map((p) =>
+        p ? p.scenarioUpper - p.scenarioLower : null
+      ),
+    ];
+
+    return {
+      animation: true,
+      backgroundColor: "transparent",
+      grid: {
+        left: "5%",
+        right: "4%",
+        bottom: "10%",
+        top: "15%",
+        containLabel: true,
+      },
+      legend: {
+        show: true,
+        top: 0,
+        right: 0,
+        textStyle: { color: textColor, fontSize: 12 },
+        data: [
+          {
+            name: "Baseline",
+            icon: "path://M0,5 L4,5 M8,5 L12,5 M16,5 L20,5",
+            itemStyle: { color: "rgba(156,163,175,0.7)" },
+            lineStyle: {
+              color: "rgba(156,163,175,0.5)",
+              type: "dotted",
+              width: 2,
+            },
+          },
+          {
+            name: "Scenario",
+            icon: "roundRect",
+            itemStyle: { color: "rgba(139,92,246,1)" },
+          },
+        ],
+      },
+      tooltip: {
+        trigger: "axis",
+        backgroundColor: isDark
+          ? "rgba(30,41,59,0.95)"
+          : "rgba(255,255,255,0.95)",
+        borderColor: isDark
+          ? "rgba(255,255,255,0.15)"
+          : "rgba(0,0,0,0.1)",
+        borderWidth: 1,
+        textStyle: {
+          color: isDark ? "rgba(241,245,249,1)" : "rgba(30,41,59,1)",
+          fontSize: 12,
+        },
+        padding: [8, 12],
+        formatter: (params: any) => {
+          if (!Array.isArray(params) || params.length === 0) return "";
+          const idx = params[0].dataIndex as number;
+          const label = xLabels[idx];
+
+          // find the visible series values (skip underscore helpers)
+          const baselineParam = params.find((p: any) => p.seriesName === "Baseline");
+          const scenarioParam = params.find((p: any) => p.seriesName === "Scenario");
+
+          return `<div style="padding:4px 0;">
+            <div style="font-weight:600;margin-bottom:6px;">${label}</div>
+            ${
+              baselineParam
+                ? `<div style="display:flex;align-items:center;gap:8px;margin-top:4px;">
+                <span style="display:inline-block;width:20px;height:2px;border-top:2px dotted rgba(156,163,175,0.7);flex-shrink:0;"></span>
+                <span style="flex:1;">Baseline:</span>
+                <span style="font-weight:600;">${formatCurrency(baselineParam.value as number)}</span>
+              </div>`
+                : ""
+            }
+            ${
+              scenarioParam
+                ? `<div style="display:flex;align-items:center;gap:8px;margin-top:4px;">
+                <span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:rgba(139,92,246,1);flex-shrink:0;"></span>
+                <span style="flex:1;">Scenario:</span>
+                <span style="font-weight:600;">${formatCurrency(scenarioParam.value as number)}</span>
+              </div>`
+                : ""
+            }
+          </div>`;
+        },
+      },
+      // No visualMap — coloring is handled by split violet/crimson series
+      // to avoid ECharts' getVisualGradient crash (coord undefined) during
+      // animation-frame updates when the coordinate system is being rebuilt.
+      xAxis: {
+        type: "category",
+        data: xLabels,
+        boundaryGap: false,
+        axisLine: { lineStyle: { color: gridColor } },
+        axisLabel: { color: textColor, fontSize: 11 },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: "value",
+        axisLine: { show: false },
+        axisLabel: {
+          color: textColor,
+          fontSize: 11,
+          formatter: (value: number) => {
+            if (Math.abs(value) >= 1000) {
+              return `€${(value / 1000).toFixed(0)}k`;
+            }
+            return `€${value.toFixed(0)}`;
+          },
+        },
+        splitLine: { lineStyle: { color: gridColor, type: "dashed" } },
+      },
+      series: [
+        // 0: Scenario band base (transparent floor at scenarioLower)
+        {
+          name: "_bandBase",
+          type: "line",
+          smooth: true,
+          showSymbol: false,
+          stack: "sandboxBand",
+          lineStyle: { width: 0, color: "transparent" },
+          areaStyle: { color: "transparent", opacity: 0 },
+          itemStyle: { color: "transparent", opacity: 0 },
+          legendHoverLink: false,
+          silent: true,
+          data: bandBaseValues,
+        },
+        // 1: Scenario band fill (stacked height = upper - lower)
+        {
+          name: "_bandFill",
+          type: "line",
+          smooth: true,
+          showSymbol: false,
+          stack: "sandboxBand",
+          lineStyle: { width: 0, color: "transparent" },
+          areaStyle: {
+            color: {
+              type: "linear",
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: `rgba(139,92,246,${bandTopAlpha})` },
+                { offset: 1, color: `rgba(139,92,246,${bandBotAlpha})` },
+              ],
+            },
+          },
+          itemStyle: { color: "transparent", opacity: 0 },
+          legendHoverLink: false,
+          silent: true,
+          data: bandFillValues,
+        },
+        // 2: Baseline — dotted grey
+        {
+          name: "Baseline",
+          type: "line",
+          smooth: true,
+          showSymbol: false,
+          z: 6,
+          lineStyle: {
+            type: "dotted",
+            color: "rgba(156,163,175,0.5)",
+            width: 2,
+          },
+          itemStyle: { color: "rgba(156,163,175,0.7)" },
+          emphasis: { focus: "series" },
+          data: baselineLine,
+        },
+        // 3: Scenario (violet) — above-zero segments
+        {
+          name: "Scenario",
+          type: "line",
+          smooth: true,
+          showSymbol: false,
+          z: 8,
+          connectNulls: false,
+          lineStyle: {
+            width: 3,
+            color: "rgba(139,92,246,1)",
+            shadowBlur: 8,
+            shadowColor: "rgba(139,92,246,0.4)",
+          },
+          itemStyle: { color: "rgba(139,92,246,1)" },
+          emphasis: { focus: "series", lineStyle: { width: 4 } },
+          data: scenarioViolet,
+        },
+        // 4: Scenario (crimson) — below-zero segments; excluded from legend
+        {
+          name: "_scenarioCrimson",
+          type: "line",
+          smooth: true,
+          showSymbol: false,
+          z: 8,
+          connectNulls: false,
+          legendHoverLink: false,
+          silent: true,
+          lineStyle: {
+            width: 3,
+            color: "rgba(239,68,68,1)",
+            shadowBlur: 8,
+            shadowColor: "rgba(239,68,68,0.4)",
+          },
+          itemStyle: { color: "rgba(239,68,68,1)" },
+          data: scenarioCrimson,
+        },
+      ],
+    };
+  }, [points, isDark, textColor, gridColor, bandTopAlpha, bandBotAlpha]);
+
+  // Debounce the option passed to ReactECharts by one tick so that any
+  // pending ECharts internal mouse/tooltip events (which hold a reference to
+  // the old coordinate system) finish processing before the chart receives a
+  // new option. Without this, rapid state updates (e.g. slider drags) cause
+  // "Cannot read properties of undefined (reading 'coord')" inside ECharts.
+  const [debouncedOption, setDebouncedOption] = useState<EChartsOption>(option);
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedOption(option), 0);
+    return () => clearTimeout(id);
+  }, [option]);
+
+  // Dispose ECharts instance on unmount to prevent memory leaks.
+  // Capture chartRef.current into a local variable at effect-setup time so
+  // the cleanup closure always references the same stable value — avoids the
+  // react-hooks/exhaustive-deps warning that ref.current may have changed by
+  // the time the cleanup runs. Wrap getEchartsInstance() in try/catch because
+  // it can throw when the underlying echarts instance was already disposed
+  // (e.g. React 18 Strict Mode double-invoke).
+  useEffect(() => {
+    const chartNode = chartRef.current;
+    return () => {
+      try {
+        const echartsInstance = chartNode?.getEchartsInstance();
+        if (echartsInstance && !echartsInstance.isDisposed()) {
+          echartsInstance.dispose();
+        }
+      } catch {
+        // Silently ignore — instance already cleaned up.
+      }
+    };
+  }, []);
+
+  return (
+    <div className="h-[320px] w-full">
+      <ReactECharts
+        ref={chartRef}
+        option={debouncedOption}
+        style={{ height: "100%", width: "100%" }}
+        notMerge={false}
+        lazyUpdate={true}
+      />
+    </div>
+  );
+}

--- a/src/components/sandbox/rule-card.tsx
+++ b/src/components/sandbox/rule-card.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import type { ScenarioRule } from "@/lib/stats/sandbox-projector";
+import type { RecurringTransactionGroup } from "@/lib/stats/categories";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface RuleCardProps {
+  readonly rule: ScenarioRule;
+  /** Detected recurring groups used to populate the subscription selector. */
+  readonly recurringGroups: RecurringTransactionGroup[];
+  onUpdate: (id: string, patch: Partial<Omit<ScenarioRule, "id">>) => void;
+  onRemove: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Type badge colors
+// ---------------------------------------------------------------------------
+
+const TYPE_STYLES: Record<ScenarioRule["type"], string> = {
+  recurring:
+    "bg-blue-500/15 text-blue-400 border border-blue-500/30",
+  onetime:
+    "bg-amber-500/15 text-amber-400 border border-amber-500/30",
+  subscription:
+    "bg-emerald-500/15 text-emerald-400 border border-emerald-500/30",
+  investment:
+    "bg-violet-500/15 text-violet-400 border border-violet-500/30",
+};
+
+const TYPE_LABELS: Record<ScenarioRule["type"], string> = {
+  recurring: "Recurring",
+  onetime: "One-Time",
+  subscription: "Subscription Cut",
+  investment: "ETF / Investment",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RuleCard({
+  rule,
+  recurringGroups,
+  onUpdate,
+  onRemove,
+}: RuleCardProps): React.JSX.Element {
+  const handleToggleEnabled = (checked: boolean): void => {
+    onUpdate(rule.id, { enabled: checked });
+  };
+
+  const handleRemove = (): void => {
+    onRemove(rule.id);
+  };
+
+  return (
+    <div
+      className={cn(
+        "bg-card/40 relative rounded-xl border border-white/10 p-4 backdrop-blur-xl transition-all duration-200",
+        !rule.enabled && "opacity-50"
+      )}
+    >
+      {/* Header row */}
+      <div className="mb-3 flex items-center gap-3">
+        <Switch
+          checked={rule.enabled}
+          onCheckedChange={handleToggleEnabled}
+          aria-label={`Toggle ${rule.name}`}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground truncate text-sm font-semibold">
+            {rule.name}
+          </p>
+          <span
+            className={cn(
+              "mt-0.5 inline-block rounded-full px-2 py-0.5 text-xs font-medium",
+              TYPE_STYLES[rule.type]
+            )}
+          >
+            {TYPE_LABELS[rule.type]}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-destructive h-7 w-7 shrink-0"
+          onClick={handleRemove}
+          aria-label={`Delete rule ${rule.name}`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Type-specific controls */}
+      {rule.type === "recurring" && (
+        <RecurringControls rule={rule} onUpdate={onUpdate} />
+      )}
+      {rule.type === "onetime" && (
+        <OneTimeControls rule={rule} onUpdate={onUpdate} />
+      )}
+      {rule.type === "subscription" && (
+        <SubscriptionControls
+          rule={rule}
+          recurringGroups={recurringGroups}
+          onUpdate={onUpdate}
+        />
+      )}
+      {rule.type === "investment" && (
+        <InvestmentControls rule={rule} onUpdate={onUpdate} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recurring controls
+// ---------------------------------------------------------------------------
+
+interface ControlsProps {
+  rule: ScenarioRule;
+  onUpdate: (id: string, patch: Partial<Omit<ScenarioRule, "id">>) => void;
+}
+
+function RecurringControls({ rule, onUpdate }: ControlsProps): React.JSX.Element {
+  const amount = rule.amount;
+  const startMonth = rule.startMonthOffset;
+
+  return (
+    <div className="space-y-4">
+      {/* Amount slider: -2000 to +2000, step 50 */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs">
+            Monthly delta
+          </Label>
+          <span
+            className={cn(
+              "text-xs font-semibold tabular-nums",
+              amount >= 0 ? "text-emerald-400" : "text-rose-400"
+            )}
+          >
+            {amount >= 0 ? "+" : ""}
+            {formatCurrency(amount)} / mo
+          </span>
+        </div>
+        <Slider
+          min={-2000}
+          max={2000}
+          step={50}
+          value={[amount]}
+          onValueChange={([v]) => onUpdate(rule.id, { amount: v })}
+          className="w-full"
+        />
+        <div className="text-muted-foreground/60 flex justify-between text-xs">
+          <span>-€2 000</span>
+          <span>+€2 000</span>
+        </div>
+      </div>
+
+      {/* Start month offset */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs">
+            Starts after
+          </Label>
+          <span className="text-xs font-semibold tabular-nums">
+            {startMonth === 0 ? "now" : `month ${startMonth}`}
+          </span>
+        </div>
+        <Slider
+          min={0}
+          max={12}
+          step={1}
+          value={[startMonth]}
+          onValueChange={([v]) =>
+            onUpdate(rule.id, { startMonthOffset: v })
+          }
+          className="w-full"
+        />
+        <div className="text-muted-foreground/60 flex justify-between text-xs">
+          <span>Now</span>
+          <span>Month 12</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// One-time controls
+// ---------------------------------------------------------------------------
+
+function OneTimeControls({ rule, onUpdate }: ControlsProps): React.JSX.Element {
+  const targetYear = rule.targetYear ?? 1;
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const parsed = parseFloat(e.target.value);
+    if (!isNaN(parsed)) {
+      onUpdate(rule.id, { amount: parsed });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Amount input */}
+      <div className="space-y-1.5">
+        <Label className="text-muted-foreground text-xs">Amount (€)</Label>
+        <Input
+          type="number"
+          value={rule.amount}
+          onChange={handleAmountChange}
+          placeholder="e.g. 5000"
+          className="bg-card/50 border-white/10 h-8 text-sm"
+          step={100}
+        />
+        <p className="text-muted-foreground/60 text-xs">
+          Positive = inflow (e.g. bonus), negative = outflow (e.g. car purchase)
+        </p>
+      </div>
+
+      {/* Target year slider */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs">
+            Applies in
+          </Label>
+          <span className="text-xs font-semibold tabular-nums">
+            Year {targetYear}
+          </span>
+        </div>
+        <Slider
+          min={1}
+          max={10}
+          step={1}
+          value={[targetYear]}
+          onValueChange={([v]) => onUpdate(rule.id, { targetYear: v })}
+          className="w-full"
+        />
+        <div className="text-muted-foreground/60 flex justify-between text-xs">
+          <span>Yr 1</span>
+          <span>Yr 10</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subscription controls
+// ---------------------------------------------------------------------------
+
+interface SubscriptionControlsProps extends ControlsProps {
+  recurringGroups: RecurringTransactionGroup[];
+}
+
+function SubscriptionControls({
+  rule,
+  recurringGroups,
+  onUpdate,
+}: SubscriptionControlsProps): React.JSX.Element {
+  const selectedName = rule.subscriptionName ?? "";
+
+  const handleSelect = (name: string): void => {
+    const group = recurringGroups.find((g) => g.counterparty === name);
+    if (group) {
+      onUpdate(rule.id, {
+        subscriptionName: name,
+        amount: Math.abs(group.averageAmount),
+        name: `Cancel: ${group.counterparty}`,
+      });
+    }
+  };
+
+  const monthlyCost = rule.amount > 0 ? rule.amount : Math.abs(rule.amount);
+
+  return (
+    <div className="space-y-4">
+      {recurringGroups.length === 0 ? (
+        <p className="text-muted-foreground/70 text-xs">
+          No recurring merchant patterns detected. Sync more transactions to
+          populate this list.
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          <Label className="text-muted-foreground text-xs">
+            Merchant to cancel
+          </Label>
+          <Select
+            value={selectedName}
+            onValueChange={handleSelect}
+          >
+            <SelectTrigger className="bg-card/50 border-white/10 h-8 text-sm">
+              <SelectValue placeholder="Select merchant…" />
+            </SelectTrigger>
+            <SelectContent>
+              {recurringGroups.map((g) => (
+                <SelectItem key={g.counterparty} value={g.counterparty}>
+                  <span className="flex items-center justify-between gap-4">
+                    <span className="truncate">{g.counterparty}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {formatCurrency(Math.abs(g.averageAmount))}/mo
+                    </span>
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {monthlyCost > 0 && (
+        <p className="text-emerald-400 text-xs">
+          Cancelling saves{" "}
+          <span className="font-semibold">{formatCurrency(monthlyCost)}</span>{" "}
+          / month
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Investment controls
+// ---------------------------------------------------------------------------
+
+function InvestmentControls({ rule, onUpdate }: ControlsProps): React.JSX.Element {
+  const annualRate = (rule.annualRate ?? 0) * 100; // stored as 0..0.12, display as %
+
+  return (
+    <div className="space-y-4">
+      {/* Monthly contribution */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs">
+            Monthly contribution
+          </Label>
+          <span className="text-emerald-400 text-xs font-semibold tabular-nums">
+            {rule.amount >= 0 ? "+" : ""}
+            {formatCurrency(rule.amount)} / mo
+          </span>
+        </div>
+        <Slider
+          min={0}
+          max={2000}
+          step={50}
+          value={[rule.amount]}
+          onValueChange={([v]) => onUpdate(rule.id, { amount: v })}
+          className="w-full"
+        />
+        <div className="text-muted-foreground/60 flex justify-between text-xs">
+          <span>€0</span>
+          <span>€2 000</span>
+        </div>
+      </div>
+
+      {/* Annual yield slider */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs">
+            Annual yield
+          </Label>
+          <span className="text-violet-400 text-xs font-semibold tabular-nums">
+            {annualRate.toFixed(1)}%
+          </span>
+        </div>
+        <Slider
+          min={0}
+          max={12}
+          step={0.5}
+          value={[annualRate]}
+          onValueChange={([v]) =>
+            onUpdate(rule.id, { annualRate: v / 100 })
+          }
+          className="w-full"
+        />
+        <div className="text-muted-foreground/60 flex justify-between text-xs">
+          <span>0%</span>
+          <span>12%</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sandbox/rule-card.tsx
+++ b/src/components/sandbox/rule-card.tsx
@@ -85,7 +85,7 @@ export function RuleCard({
   return (
     <div
       className={cn(
-        "bg-card/40 relative rounded-xl border border-white/10 p-4 backdrop-blur-xl transition-all duration-200",
+        "bg-card relative rounded-xl border border-border p-4 backdrop-blur-xl transition-all duration-200 dark:bg-card/80",
         !rule.enabled && "opacity-50"
       )}
     >
@@ -156,7 +156,7 @@ function RecurringControls({ rule, onUpdate }: ControlsProps): React.JSX.Element
 
   return (
     <div className="space-y-4">
-      {/* Amount slider: -2000 to +2000, step 50 */}
+      {/* Amount slider: -5000 to +5000, step 50 */}
       <div className="space-y-1.5">
         <div className="flex items-center justify-between">
           <Label className="text-muted-foreground text-xs">
@@ -173,16 +173,16 @@ function RecurringControls({ rule, onUpdate }: ControlsProps): React.JSX.Element
           </span>
         </div>
         <Slider
-          min={-2000}
-          max={2000}
+          min={-5000}
+          max={5000}
           step={50}
           value={[amount]}
           onValueChange={([v]) => onUpdate(rule.id, { amount: v })}
           className="w-full"
         />
         <div className="text-muted-foreground/60 flex justify-between text-xs">
-          <span>-€2 000</span>
-          <span>+€2 000</span>
+          <span>-€5 000</span>
+          <span>+€5 000</span>
         </div>
       </div>
 
@@ -239,7 +239,7 @@ function OneTimeControls({ rule, onUpdate }: ControlsProps): React.JSX.Element {
           value={rule.amount}
           onChange={handleAmountChange}
           placeholder="e.g. 5000"
-          className="bg-card/50 border-white/10 h-8 text-sm"
+          className="bg-background border-border h-8 text-sm"
           step={100}
         />
         <p className="text-muted-foreground/60 text-xs">
@@ -318,7 +318,7 @@ function SubscriptionControls({
             value={selectedName}
             onValueChange={handleSelect}
           >
-            <SelectTrigger className="bg-card/50 border-white/10 h-8 text-sm">
+            <SelectTrigger className="bg-background border-border h-8 text-sm">
               <SelectValue placeholder="Select merchant…" />
             </SelectTrigger>
             <SelectContent>
@@ -370,7 +370,7 @@ function InvestmentControls({ rule, onUpdate }: ControlsProps): React.JSX.Elemen
         </div>
         <Slider
           min={0}
-          max={2000}
+          max={5000}
           step={50}
           value={[rule.amount]}
           onValueChange={([v]) => onUpdate(rule.id, { amount: v })}
@@ -378,7 +378,7 @@ function InvestmentControls({ rule, onUpdate }: ControlsProps): React.JSX.Elemen
         />
         <div className="text-muted-foreground/60 flex justify-between text-xs">
           <span>€0</span>
-          <span>€2 000</span>
+          <span>€5 000</span>
         </div>
       </div>
 

--- a/src/components/sandbox/rule-card.tsx
+++ b/src/components/sandbox/rule-card.tsx
@@ -318,15 +318,15 @@ function SubscriptionControls({
             value={selectedName}
             onValueChange={handleSelect}
           >
-            <SelectTrigger className="bg-background border-border h-8 text-sm">
+            <SelectTrigger className="h-8 w-full min-w-0 text-sm">
               <SelectValue placeholder="Select merchant…" />
             </SelectTrigger>
             <SelectContent>
               {recurringGroups.map((g) => (
                 <SelectItem key={g.counterparty} value={g.counterparty}>
-                  <span className="flex items-center justify-between gap-4">
-                    <span className="truncate">{g.counterparty}</span>
-                    <span className="text-muted-foreground text-xs">
+                  <span className="flex w-full min-w-0 items-center justify-between gap-2">
+                    <span className="min-w-0 truncate">{g.counterparty}</span>
+                    <span className="text-muted-foreground shrink-0 text-xs">
                       {formatCurrency(Math.abs(g.averageAmount))}/mo
                     </span>
                   </span>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit min-w-0 items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm whitespace-nowrap outline-none transition-all duration-200 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 bg-card/50 border-white/10 backdrop-blur-xl dark:border-white/5 hover:bg-card/70 hover:border-primary/20",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-card/95 text-popover-foreground backdrop-blur-xl border-white/10 dark:border-white/5 shadow-primary/5 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/hooks/use-scenarios.ts
+++ b/src/hooks/use-scenarios.ts
@@ -1,0 +1,266 @@
+/**
+ * use-scenarios — client-side hook for managing named What-If sandbox scenarios.
+ *
+ * Scenarios are persisted to localStorage under `STORAGE_KEY` and survive
+ * page reloads. A default empty scenario is created automatically on first
+ * use. The hook is SSR-safe: localStorage is only accessed inside the lazy
+ * `useState` initialiser, which runs only on the client.
+ *
+ * This hook never reads from or writes to the database. It is read-only with
+ * respect to banking data.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ScenarioRule } from "@/lib/stats/sandbox-projector";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "banking:sandbox:scenarios:v1";
+const DEFAULT_SCENARIO_ID = "default";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface Scenario {
+  readonly id: string;
+  readonly name: string;
+  readonly rules: ScenarioRule[];
+}
+
+export type ScenariosMap = Record<string, Scenario>;
+
+export interface UseScenariosReturn {
+  /** All persisted named scenarios, keyed by id. */
+  readonly scenarios: ScenariosMap;
+  /** The currently active scenario id (default: "default"). */
+  readonly activeScenarioId: string;
+  /** Switch the active scenario. */
+  setActiveScenarioId: (id: string) => void;
+  /** Add a rule to the active scenario. Generates a fresh UUID for the rule. */
+  addRule: (rule: Omit<ScenarioRule, "id">) => void;
+  /** Patch one or more fields of an existing rule in the active scenario. */
+  updateRule: (id: string, patch: Partial<Omit<ScenarioRule, "id">>) => void;
+  /** Remove a rule by id from the active scenario. */
+  removeRule: (id: string) => void;
+  /** Persist the active scenario's rules as a new named scenario. */
+  saveAsNew: (name: string) => void;
+  /** Rename an existing scenario. */
+  renameScenario: (id: string, name: string) => void;
+  /** Delete a scenario by id. Falls back to "default" if the active one is deleted. */
+  deleteScenario: (id: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createDefaultScenario(): Scenario {
+  return {
+    id: DEFAULT_SCENARIO_ID,
+    name: "Default",
+    rules: [],
+  };
+}
+
+function buildInitialState(): ScenariosMap {
+  return { [DEFAULT_SCENARIO_ID]: createDefaultScenario() };
+}
+
+/**
+ * Attempts to read and parse the scenarios map from localStorage.
+ * Returns `null` when running on the server, when the key is absent, or
+ * when the stored value is not a plain object.
+ */
+function loadFromStorage(): ScenariosMap | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as ScenariosMap;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists the scenarios map to localStorage. Fails silently (quota exceeded
+ * or private-browsing restriction).
+ */
+function saveToStorage(scenarios: ScenariosMap): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(scenarios));
+  } catch {
+    // Intentionally silent.
+  }
+}
+
+/**
+ * Lazy initialiser for the `scenarios` useState call. Runs once on the
+ * client, reads from localStorage, and ensures the default scenario exists.
+ */
+function initScenarios(): ScenariosMap {
+  const stored = loadFromStorage();
+  if (stored === null) return buildInitialState();
+
+  // Ensure the default scenario always exists after hydration.
+  if (!stored[DEFAULT_SCENARIO_ID]) {
+    return { [DEFAULT_SCENARIO_ID]: createDefaultScenario(), ...stored };
+  }
+  return stored;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages multiple named What-If scenarios, each holding an array of
+ * `ScenarioRule` objects. State is hydrated from and persisted to
+ * localStorage on every change.
+ */
+export function useScenarios(): UseScenariosReturn {
+  // Lazy initialiser reads from localStorage on first render (client only).
+  const [scenarios, setScenarios] = useState<ScenariosMap>(initScenarios);
+  const [activeScenarioId, setActiveScenarioIdState] =
+    useState<string>(DEFAULT_SCENARIO_ID);
+
+  // Track whether this is the first render so we skip the initial persist
+  // (no point writing back what we just read).
+  const isFirstRender = useRef(true);
+
+  // Persist to localStorage whenever scenarios change, skipping the mount.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    saveToStorage(scenarios);
+  }, [scenarios]);
+
+  // ---------------------------------------------------------------------------
+  // Setters
+  // ---------------------------------------------------------------------------
+
+  const setActiveScenarioId = useCallback((id: string): void => {
+    setActiveScenarioIdState(id);
+  }, []);
+
+  const addRule = useCallback(
+    (rule: Omit<ScenarioRule, "id">): void => {
+      const id = crypto.randomUUID();
+      const newRule: ScenarioRule = { ...rule, id } as ScenarioRule;
+      setScenarios((prev) => {
+        const active = prev[activeScenarioId];
+        if (!active) return prev;
+        return {
+          ...prev,
+          [activeScenarioId]: {
+            ...active,
+            rules: [...active.rules, newRule],
+          },
+        };
+      });
+    },
+    [activeScenarioId]
+  );
+
+  const updateRule = useCallback(
+    (ruleId: string, patch: Partial<Omit<ScenarioRule, "id">>): void => {
+      setScenarios((prev) => {
+        const active = prev[activeScenarioId];
+        if (!active) return prev;
+        return {
+          ...prev,
+          [activeScenarioId]: {
+            ...active,
+            rules: active.rules.map((r) =>
+              r.id === ruleId ? ({ ...r, ...patch } as ScenarioRule) : r
+            ),
+          },
+        };
+      });
+    },
+    [activeScenarioId]
+  );
+
+  const removeRule = useCallback(
+    (ruleId: string): void => {
+      setScenarios((prev) => {
+        const active = prev[activeScenarioId];
+        if (!active) return prev;
+        return {
+          ...prev,
+          [activeScenarioId]: {
+            ...active,
+            rules: active.rules.filter((r) => r.id !== ruleId),
+          },
+        };
+      });
+    },
+    [activeScenarioId]
+  );
+
+  const saveAsNew = useCallback(
+    (name: string): void => {
+      const newId = crypto.randomUUID();
+      setScenarios((prev) => {
+        const active = prev[activeScenarioId];
+        if (!active) return prev;
+        const newScenario: Scenario = {
+          id: newId,
+          name,
+          // Deep-copy rules so the new scenario is independent.
+          rules: active.rules.map((r) => ({ ...r })),
+        };
+        return { ...prev, [newId]: newScenario };
+      });
+      setActiveScenarioIdState(newId);
+    },
+    [activeScenarioId]
+  );
+
+  const renameScenario = useCallback((id: string, name: string): void => {
+    setScenarios((prev) => {
+      const target = prev[id];
+      if (!target) return prev;
+      return { ...prev, [id]: { ...target, name } };
+    });
+  }, []);
+
+  const deleteScenario = useCallback((id: string): void => {
+    // The default scenario cannot be deleted.
+    if (id === DEFAULT_SCENARIO_ID) return;
+    setScenarios((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    // If the deleted scenario was active, fall back to default.
+    setActiveScenarioIdState((prev) =>
+      prev === id ? DEFAULT_SCENARIO_ID : prev
+    );
+  }, []);
+
+  return {
+    scenarios,
+    activeScenarioId,
+    setActiveScenarioId,
+    addRule,
+    updateRule,
+    removeRule,
+    saveAsNew,
+    renameScenario,
+    deleteScenario,
+  };
+}

--- a/src/lib/stats/calculations.ts
+++ b/src/lib/stats/calculations.ts
@@ -479,6 +479,42 @@ export function calculateMonthlyAverages(
   };
 }
 
+// --- Shared Projection Helpers ---
+
+/**
+ * Selects the trailing window of complete monthly-flow records to use for
+ * balance projections. Mirrors the window-selection logic in
+ * `calculateBalancePrediction` so that the sandbox baseline matches the
+ * Insights forecast at yearly marks.
+ *
+ * Rules:
+ * - Excludes `currentMonth` (partial month).
+ * - Requires at least `minMonths` complete months (default 3).
+ * - Uses at most the trailing 12 complete months.
+ *
+ * Returns `null` when the data is insufficient.
+ */
+export function selectProjectionWindow(
+  monthlyCashFlow: readonly MonthlyFlow[],
+  currentMonth: string,
+  minMonths: number = 3
+): { window: MonthlyFlow[]; mean: number; stdDev: number } | null {
+  const completeMonths = monthlyCashFlow.filter(
+    (m) => m.month !== currentMonth
+  );
+
+  if (completeMonths.length < minMonths) {
+    return null;
+  }
+
+  const historyWindow = completeMonths.slice(-12);
+  const netValues = historyWindow.map((m) => m.net);
+  const mean = netValues.reduce((sum, v) => sum + v, 0) / historyWindow.length;
+  const stdDev = calculateStandardDeviation(netValues);
+
+  return { window: historyWindow, mean, stdDev };
+}
+
 // --- Balance Prediction ---
 
 export interface BalancePredictionPoint {
@@ -529,30 +565,22 @@ export function calculateBalancePrediction(
   // Derive current month string (YYYY-MM)
   const currentMonth = input.currentMonth ?? format(new Date(), "yyyy-MM");
 
-  // Exclude the current (partial) month from history
+  // Guard: no-data if truly empty with zero balance
   const completeMonths = monthlyCashFlow.filter(
     (m) => m.month !== currentMonth
   );
-
-  // Guard: no-data if truly empty with zero balance
   if (completeMonths.length === 0 && totalBalance === 0) {
     return { available: false, reason: "no-data" };
   }
 
-  // Guard: need at least 3 complete months
-  if (completeMonths.length < 3) {
+  // Derive mean/stdDev using the shared window-selection helper
+  const projection = selectProjectionWindow(monthlyCashFlow, currentMonth);
+  if (projection === null) {
     return { available: false, reason: "insufficient-history" };
   }
 
-  // Take trailing min(count, 12) months
-  const historyWindow = completeMonths.slice(-12);
+  const { window: historyWindow, mean: meanMonthlyNet, stdDev: stdDevMonthlyNet } = projection;
   const monthsUsed = historyWindow.length;
-
-  const netValues = historyWindow.map((m) => m.net);
-
-  const meanMonthlyNet = netValues.reduce((sum, v) => sum + v, 0) / monthsUsed;
-
-  const stdDevMonthlyNet = calculateStandardDeviation(netValues);
 
   // Confidence classification
   let confidence: BalancePrediction["confidence"];

--- a/src/lib/stats/sandbox-projector.ts
+++ b/src/lib/stats/sandbox-projector.ts
@@ -96,7 +96,10 @@ function roundCents(value: number): number {
  *
  * - `recurring` rules contribute `amount` when `m >= startMonthOffset`.
  * - `subscription` rules contribute `amount` (treated as positive) every month.
- * - `onetime` and `investment` rules are NOT handled here.
+ * - `investment` rules contribute `amount` as a monthly deposit every month
+ *   (the deposit is added to the running balance before interest compounds,
+ *   so the yield then applies to the growing principal).
+ * - `onetime` rules are NOT handled here (see `computeOneTimeDelta`).
  */
 function computeRecurringDelta(
   rules: readonly ScenarioRule[],
@@ -115,6 +118,12 @@ function computeRecurringDelta(
       // Cancelling a subscription removes an expense, adding the amount back.
       // `amount` should already be positive (absolute cost per month).
       delta += Math.abs(rule.amount);
+    }
+
+    if (rule.type === "investment") {
+      // Monthly contribution — deposited every month regardless of start offset.
+      // This grows the balance that `computeInterest` then compounds on.
+      delta += rule.amount;
     }
   }
 

--- a/src/lib/stats/sandbox-projector.ts
+++ b/src/lib/stats/sandbox-projector.ts
@@ -1,0 +1,263 @@
+/**
+ * What-If Financial Sandbox — simulation engine.
+ *
+ * Computes monthly balance projections for up to 10 years (120 points) given
+ * a set of scenario rules layered on top of the historical baseline. The
+ * baseline is derived from the same trailing-window logic used by
+ * `calculateBalancePrediction` on the Insights page, so yearly marks are
+ * consistent between the two features.
+ *
+ * This module is pure (no I/O, no DB access). All inputs are passed in.
+ */
+
+import { format } from "date-fns";
+
+import {
+  selectProjectionWindow,
+  type MonthlyFlow,
+} from "@/lib/stats/calculations";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single scenario rule that modifies the baseline projection.
+ *
+ * - `recurring`     — a fixed monthly cash-flow delta starting at `startMonthOffset`.
+ * - `onetime`       — a lump-sum applied once at month `targetYear * 12`.
+ * - `subscription`  — models cancelling a recurring expense; the matched
+ *                     counterparty's `averageAmount` is added back (positive)
+ *                     for every month as long as the rule is enabled.
+ * - `investment`    — compound interest applied to the running balance each
+ *                     month at `annualRate / 12`.
+ */
+export interface ScenarioRule {
+  readonly id: string;
+  readonly type: "recurring" | "onetime" | "subscription" | "investment";
+  readonly name: string;
+  readonly enabled: boolean;
+  /** Signed monthly delta for `recurring`; lump-sum for `onetime`. */
+  readonly amount: number;
+  /** `recurring`: applies for months m >= startMonthOffset. Ignored for `onetime`. */
+  readonly startMonthOffset: number;
+  /** `onetime`: target month = targetYear * 12. Range 1..10. */
+  readonly targetYear?: number;
+  /** `investment`: annual rate 0..0.12. */
+  readonly annualRate?: number;
+  /** `subscription`: matched counterparty name — cost added back as positive delta. */
+  readonly subscriptionName?: string;
+}
+
+/**
+ * A single monthly data point produced by the sandbox engine.
+ * Month 0 is the current balance (no projection); months 1..N are forward.
+ */
+export interface SandboxPoint {
+  readonly month: number;
+  /** Baseline projected balance (no scenario rules). */
+  readonly baseline: number;
+  /** Baseline minus one-sigma spread. */
+  readonly baselineLower: number;
+  /** Baseline plus one-sigma spread. */
+  readonly baselineUpper: number;
+  /** Scenario-adjusted running balance. */
+  readonly scenario: number;
+  /** Scenario balance minus one-sigma spread. */
+  readonly scenarioLower: number;
+  /** Scenario balance plus one-sigma spread. */
+  readonly scenarioUpper: number;
+}
+
+export type SandboxResult =
+  | {
+      readonly status: "ok";
+      readonly points: SandboxPoint[];
+      readonly meanMonthlyNet: number;
+      readonly stdDevMonthlyNet: number;
+    }
+  | {
+      readonly status: "insufficient-data";
+      readonly reason: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Round a monetary value to the nearest cent. */
+function roundCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Compute the net recurring delta contributed by all enabled rules for a
+ * given month index `m` (1-based).
+ *
+ * - `recurring` rules contribute `amount` when `m >= startMonthOffset`.
+ * - `subscription` rules contribute `amount` (treated as positive) every month.
+ * - `onetime` and `investment` rules are NOT handled here.
+ */
+function computeRecurringDelta(
+  rules: readonly ScenarioRule[],
+  m: number
+): number {
+  let delta = 0;
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+
+    if (rule.type === "recurring" && m >= rule.startMonthOffset) {
+      delta += rule.amount;
+    }
+
+    if (rule.type === "subscription") {
+      // Cancelling a subscription removes an expense, adding the amount back.
+      // `amount` should already be positive (absolute cost per month).
+      delta += Math.abs(rule.amount);
+    }
+  }
+
+  return delta;
+}
+
+/**
+ * Compute the interest earned in month `m` given the balance at the end of
+ * the previous month `prevBalance`. Sums contributions from all enabled
+ * investment rules.
+ */
+function computeInterest(
+  rules: readonly ScenarioRule[],
+  prevBalance: number
+): number {
+  let interest = 0;
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (rule.type !== "investment") continue;
+
+    const annualRate = rule.annualRate ?? 0;
+    interest += prevBalance * (annualRate / 12);
+  }
+
+  return interest;
+}
+
+/**
+ * Compute the one-time lump-sum delta applied at exactly month `m`.
+ * `targetYear` maps to month index `targetYear * 12`.
+ */
+function computeOneTimeDelta(
+  rules: readonly ScenarioRule[],
+  m: number
+): number {
+  let delta = 0;
+
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (rule.type !== "onetime") continue;
+
+    const targetMonth = (rule.targetYear ?? 1) * 12;
+    if (m === targetMonth) {
+      delta += rule.amount;
+    }
+  }
+
+  return delta;
+}
+
+// ---------------------------------------------------------------------------
+// Main exported function
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes a monthly sandbox projection for `years` years (default 10,
+ * yielding 120 monthly points).
+ *
+ * The baseline uses the same mean/stdDev derivation as
+ * `calculateBalancePrediction` so that the two are numerically consistent at
+ * yearly marks. The scenario layer iterates month-by-month, accumulating rule
+ * contributions on top of the baseline mean.
+ *
+ * @param totalBalance     Current total portfolio balance (from `getTotalBalance`).
+ * @param monthlyCashFlow  Chronological monthly flow array (from `calculateMonthlyFlow`).
+ * @param rules            Scenario rules to apply (may be empty — baseline only).
+ * @param years            Projection horizon in years. Default 10 (120 monthly points).
+ * @param currentMonth     Override for "now" in YYYY-MM format; defaults to today.
+ * @returns                `SandboxResult` — either the projection data or an
+ *                         insufficient-data indicator with a human-readable reason.
+ */
+export function calculateSandboxPrediction(
+  totalBalance: number,
+  monthlyCashFlow: readonly MonthlyFlow[],
+  rules: readonly ScenarioRule[],
+  years: number = 10,
+  currentMonth?: string
+): SandboxResult {
+  const resolvedCurrentMonth =
+    currentMonth ?? format(new Date(), "yyyy-MM");
+
+  // Derive mean and stdDev using the shared window helper (same as Insights).
+  const projectionWindow = selectProjectionWindow(
+    monthlyCashFlow,
+    resolvedCurrentMonth
+  );
+
+  if (projectionWindow === null) {
+    return {
+      status: "insufficient-data",
+      reason:
+        "At least 3 complete months of transaction history are required to run a projection. " +
+        `Only ${
+          monthlyCashFlow.filter((m) => m.month !== resolvedCurrentMonth).length
+        } complete month(s) found.`,
+    };
+  }
+
+  const { mean: meanMonthlyNet, stdDev: stdDevMonthlyNet } = projectionWindow;
+
+  const totalMonths = years * 12;
+  const points: SandboxPoint[] = [];
+
+  // Scenario running balance — starts at the current total.
+  let scenarioBalance = totalBalance;
+
+  for (let m = 1; m <= totalMonths; m++) {
+    // --- Baseline (no rules) ---
+    const baseline = roundCents(totalBalance + meanMonthlyNet * m);
+    const spread = roundCents(stdDevMonthlyNet * Math.sqrt(m));
+    const baselineLower = roundCents(baseline - spread);
+    const baselineUpper = roundCents(baseline + spread);
+
+    // --- Scenario (iterative) ---
+    const recurringDelta = computeRecurringDelta(rules, m);
+    const interest = computeInterest(rules, scenarioBalance);
+    const oneTimeDelta = computeOneTimeDelta(rules, m);
+
+    const netForMonth = meanMonthlyNet + recurringDelta + interest + oneTimeDelta;
+    // Keep full floating-point precision during accumulation to avoid
+    // cent-rounding drift vs. the closed-form baseline. Round only on output.
+    scenarioBalance = scenarioBalance + netForMonth;
+
+    const scenarioRounded = roundCents(scenarioBalance);
+    const scenarioLower = roundCents(scenarioBalance - spread);
+    const scenarioUpper = roundCents(scenarioBalance + spread);
+
+    points.push({
+      month: m,
+      baseline,
+      baselineLower,
+      baselineUpper,
+      scenario: scenarioRounded,
+      scenarioLower,
+      scenarioUpper,
+    });
+  }
+
+  return {
+    status: "ok",
+    points,
+    meanMonthlyNet: roundCents(meanMonthlyNet),
+    stdDevMonthlyNet: roundCents(stdDevMonthlyNet),
+  };
+}


### PR DESCRIPTION
## What this adds

A new standalone **Scenario Playground** at `/sandbox` where users define toggleable "what-if" financial rules and visualize their 10-year impact against the baseline forecast.

Rule types:
- **Recurring** income/expense change (with a start-month offset)
- **One-time** event (e.g. a big purchase) at a chosen year
- **Cut subscription** — pick a detected recurring merchant; cancelling adds its cost back
- **ETF yield** — compound annual return on the running balance

## Highlights

- **Baseline matches Insights exactly.** The simulation reuses the existing yearly-forecast's mean/std-dev window (`selectProjectionWindow`, extracted as a shared helper — no behavior change to the existing forecast). The scenario balance accumulates at full precision and rounds only on output, so an untouched scenario equals the baseline to the cent.
- **ECharts comparison chart**: dotted grey baseline + glowing violet scenario line, with a `visualMap` that turns any below-zero segment crimson, plus a translucent confidence band.
- **Comparative delta widget** (Yr 1 / 5 / 10) and a **Safety-Net coverage badge**.
- **Named scenarios persist** to localStorage (create / rename / save-as-new / delete).
- **Read-only**: the feature never writes to the DB.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` at pre-existing baseline (zero new problems from this feature)
- `npm run build` passes; `/sandbox` prerenders
- Manual visual QA across 7 cases (load, recurring raises line, one-time forces crimson deficit, toggle-off snaps back to baseline, delta + safety-net update, console clean, persistence-after-reload). QA tooling/screenshots are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scenario Playground: create, edit, save, and switch named what‑if financial scenarios with recurring, one‑time, subscription, and investment rules
  * 10‑year comparison visualization and delta widgets; new Sandbox nav link

* **Bug Fixes**
  * Multiple sandbox chart and projection crash fixes and slider/visual quirks resolved

* **Documentation**
  * Project state updated with sandbox workstream, QA sessions, and verification notes

* **Style**
  * Updated select control visuals for a blurred card-like appearance

* **Chores**
  * .gitignore and lint ignores updated; minor dependency bump
<!-- end of auto-generated comment: release notes by coderabbit.ai -->