### PR TITLE
feat(insights): Wants vs. Needs budget splitter (50/30/20)

### DIFF
--- a/docs/PROJECT-STATE.md
+++ b/docs/PROJECT-STATE.md
@@ -1,9 +1,51 @@
 # Project State: BanKing
 
-**Current Phase:** What-If Financial Sandbox — Bug Fixes ✅ COMPLETE
-**Current Sprint:** feat/what-if-sandbox
-**Last Session:** 2026-06-07
-**Branch:** feat/what-if-sandbox
+**Current Phase:** Wants vs. Needs Budget Splitter ✅ COMPLETE
+**Current Sprint:** feat/budget-split-insights
+**Last Session:** 2026-06-08
+**Branch:** feat/budget-split-insights
+
+---
+
+## This session changes (2026-06-08) — Wants vs. Needs Budget Splitter
+
+**Summary:** Implemented the "Budget Allocation" (Wants vs. Needs) feature on the Insights page. Added a pure calculation function, a new presentational component, and wired both into the existing Insights client page. Zero new lint errors (baseline 36 unchanged). `npx tsc --noEmit` clean. Visual QA passed in both dark and light modes.
+
+**Files Created:**
+
+- `src/components/dashboard/budget-split-strip.tsx` — Presentational "Budget Allocation" card. Renders three labeled figures (Needs/Wants/Saved), a three-segment animated bar, 50/30/20 benchmark coaching line, and an amber deficit banner. Uses `border-border` (theme-aware) for light-mode safety. Full ARIA attributes on the `role="meter"` bar.
+
+**Files Modified:**
+
+- `src/lib/stats/calculations.ts` — Added `BudgetSplitResult` interface and `calculateBudgetSplit(transactions)` pure function. Needs = `Rent | Bills | Groceries | Transport | Healthcare`. Wants = `Dining | Entertainment | Shopping | Subscriptions | Other`. Percentage denominator = income when saving, outflow when in deficit. Divide-by-zero guarded. Strict TypeScript, `readonly` parameter.
+- `src/app/(dashboard)/insights/page.tsx` — Imported `calculateBudgetSplit`, `BudgetSplitResult`, `BudgetSplitStrip`. Added `budgetSplit` useMemo. Mounted `<BudgetSplitStrip>` in a `motion.div` entrance between the Balance Forecast card and the `md:grid-cols-2` analytics grid.
+
+**Category mapping used (all match real Category union exactly):**
+
+| Bucket | Categories |
+|--------|-----------|
+| Needs  | `Rent`, `Bills`, `Groceries`, `Transport`, `Healthcare` |
+| Wants  | `Dining`, `Entertainment`, `Shopping`, `Subscriptions`, `Other` |
+
+No deviations from the spec — all category names match the `CATEGORIES` const in `src/lib/stats/categories.ts`.
+
+**Verification:**
+
+- `npx tsc --noEmit` — clean (no errors)
+- `npm run lint` — 36 problems, all pre-existing; zero new issues in created/modified files
+- `npx prettier --write` — all three changed files formatted
+- Visual QA: Playwright headless screenshots saved to `qa/budget-split-{dark,light}-{full,card}.png`. Confirmed both themes: card renders with correct glassmorphic styling, segmented bar shows three distinct colored segments (violet-blue/pink/emerald), coaching line present, borders legible in light mode (`border-border` token), amounts in de-DE EUR format.
+
+**QA screenshots (gitignored `qa/`):**
+
+- `qa/budget-split-dark-full.png` — dark mode, full Insights page
+- `qa/budget-split-dark-card.png` — dark mode, card crop
+- `qa/budget-split-light-full.png` — light mode, full Insights page
+- `qa/budget-split-light-card.png` — light mode, card crop
+
+**Next actions:**
+
+- PR / merge `feat/budget-split-insights` into main once lead reviews.
 
 ---
 

--- a/src/app/(dashboard)/insights/page.tsx
+++ b/src/app/(dashboard)/insights/page.tsx
@@ -24,13 +24,16 @@ import {
   calculateExpenseVolatility,
   calculateBalancePrediction,
   calculateMonthlyCashFlow,
+  calculateBudgetSplit,
   type EmergencyFund,
   type ExpenseVolatility,
+  type BudgetSplitResult,
 } from "@/lib/stats/calculations";
 import {
   detectRecurring,
   type RecurringTransactionGroup,
 } from "@/lib/stats/categories";
+import { BudgetSplitStrip } from "@/components/dashboard/budget-split-strip";
 import type { UnifiedTransaction } from "@/lib/banking/types";
 import { format, parseISO, getDay } from "date-fns";
 
@@ -142,6 +145,12 @@ export default function InsightsPage() {
         years: 10,
       }),
     [balance, transactions]
+  );
+
+  // Budget split — Wants vs. Needs (50/30/20 framework)
+  const budgetSplit = useMemo(
+    (): BudgetSplitResult => calculateBudgetSplit(transactions),
+    [transactions]
   );
 
   // Calculate daily spending with income markers
@@ -883,6 +892,15 @@ export default function InsightsPage() {
               </MotionCard>
             )}
           </div>
+
+          {/* ── Budget Allocation (full-width, below forecast) ── */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.08 }}
+          >
+            <BudgetSplitStrip result={budgetSplit} />
+          </motion.div>
 
           {/* ── Existing analytics grid ── */}
           <div className="grid gap-6 md:grid-cols-2">

--- a/src/components/dashboard/budget-split-strip.tsx
+++ b/src/components/dashboard/budget-split-strip.tsx
@@ -1,0 +1,224 @@
+/**
+ * BudgetSplitStrip — "Wants vs. Needs" Budget Allocation card for the Insights page.
+ *
+ * Renders a full-width glassmorphic card with:
+ * - Three labeled figures (Needs / Wants / Saved) with percentage + EUR amount.
+ * - A segmented progress bar whose widths animate to the three percentages.
+ * - A coaching line comparing actuals to the 50/30/20 benchmark.
+ * - An amber deficit banner when spending exceeds income.
+ *
+ * This is a presentational component; all computation is done by the parent page
+ * via `calculateBudgetSplit` and passed in as `result`.
+ */
+
+import { Scale } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { BudgetSplitResult } from "@/lib/stats/calculations";
+
+interface BudgetSplitStripProps {
+  result: BudgetSplitResult;
+}
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat("de-DE", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+/** Returns a short coaching note comparing actuals to the 50/30/20 ideal. */
+function coachingNote(result: BudgetSplitResult): string {
+  const { needsPercentage, wantsPercentage, savedPercentage, deficit } = result;
+
+  if (deficit < 0) {
+    return "You are spending more than you earn. Try to reduce discretionary spending to get back on track.";
+  }
+
+  const notes: string[] = [];
+
+  if (needsPercentage > 55) {
+    notes.push(
+      `Your essential expenses (${needsPercentage.toFixed(0)}%) are above the 50% guideline — consider reviewing fixed costs.`
+    );
+  } else if (needsPercentage < 40) {
+    notes.push(
+      `Your essential expenses (${needsPercentage.toFixed(0)}%) are well below 50% — great budget flexibility.`
+    );
+  }
+
+  if (wantsPercentage > 35) {
+    notes.push(
+      `You are spending more on wants (${wantsPercentage.toFixed(0)}%) than the 30% guideline.`
+    );
+  }
+
+  if (savedPercentage >= 20) {
+    notes.push(
+      `You are saving ${savedPercentage.toFixed(0)}% — meeting or exceeding the 20% savings target.`
+    );
+  } else if (savedPercentage > 0) {
+    notes.push(
+      `You are saving ${savedPercentage.toFixed(0)}% — aim for 20% to hit the benchmark.`
+    );
+  }
+
+  if (notes.length === 0) {
+    return "Your spending is close to the 50/30/20 ideal. Keep it up!";
+  }
+
+  return notes[0];
+}
+
+export function BudgetSplitStrip({ result }: BudgetSplitStripProps) {
+  const {
+    needs,
+    wants,
+    saved,
+    needsPercentage,
+    wantsPercentage,
+    savedPercentage,
+    deficit,
+  } = result;
+
+  const hasDeficit = deficit < 0;
+
+  return (
+    <Card className="border-border relative overflow-hidden md:col-span-2">
+      {/* Soft gradient overlay consistent with sibling Insights cards */}
+      <div className="absolute inset-0 bg-gradient-to-br from-violet-500/5 via-transparent to-pink-500/5 opacity-50" />
+
+      <CardHeader className="relative z-10 pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Scale className="h-5 w-5 text-violet-400" />
+              Budget Allocation
+            </CardTitle>
+            <p className="text-muted-foreground mt-1 text-sm">50/30/20 Rule</p>
+          </div>
+
+          {/* Three labeled figures */}
+          <div className="flex flex-wrap gap-6 text-right sm:gap-10">
+            {/* Needs */}
+            <div>
+              <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Needs
+              </p>
+              <p className="text-lg font-bold text-violet-500 dark:text-violet-400">
+                {needsPercentage.toFixed(0)}%
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {formatCurrency(needs)}
+              </p>
+            </div>
+
+            {/* Wants */}
+            <div>
+              <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Wants
+              </p>
+              <p className="text-lg font-bold text-pink-500 dark:text-pink-400">
+                {wantsPercentage.toFixed(0)}%
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {formatCurrency(wants)}
+              </p>
+            </div>
+
+            {/* Saved */}
+            <div>
+              <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Saved
+              </p>
+              <p
+                className={cn(
+                  "text-lg font-bold",
+                  hasDeficit
+                    ? "text-amber-500 dark:text-amber-400"
+                    : "text-emerald-500 dark:text-emerald-400"
+                )}
+              >
+                {savedPercentage.toFixed(0)}%
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {formatCurrency(saved)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="relative z-10 space-y-4">
+        {/* Deficit warning banner */}
+        {hasDeficit && (
+          <div className="flex items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+            <span className="text-sm font-semibold text-amber-600 dark:text-amber-400">
+              You spent more than you earned this period (
+              {formatCurrency(deficit)}).
+            </span>
+          </div>
+        )}
+
+        {/* Segmented bar */}
+        <div
+          className="flex h-4 w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10"
+          role="meter"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(
+            needsPercentage + wantsPercentage + savedPercentage
+          )}
+          aria-label={`Budget allocation: ${needsPercentage.toFixed(0)}% needs, ${wantsPercentage.toFixed(0)}% wants, ${savedPercentage.toFixed(0)}% saved`}
+        >
+          {/* Needs segment — violet-blue */}
+          {needsPercentage > 0 && (
+            <div
+              className="h-full bg-gradient-to-r from-violet-500 to-indigo-500 shadow-[0_0_8px_rgba(139,92,246,0.5)] transition-[width] duration-500 ease-out"
+              style={{ width: `${needsPercentage}%` }}
+            />
+          )}
+
+          {/* Wants segment — pink/magenta */}
+          {wantsPercentage > 0 && (
+            <div
+              className="h-full bg-gradient-to-r from-pink-500 to-fuchsia-500 shadow-[0_0_8px_rgba(236,72,153,0.5)] transition-[width] duration-500 ease-out"
+              style={{ width: `${wantsPercentage}%` }}
+            />
+          )}
+
+          {/* Saved segment — emerald/teal; hidden in deficit state */}
+          {!hasDeficit && savedPercentage > 0 && (
+            <div
+              className="h-full bg-gradient-to-r from-emerald-500 to-teal-500 shadow-[0_0_8px_rgba(16,185,129,0.5)] transition-[width] duration-500 ease-out"
+              style={{ width: `${savedPercentage}%` }}
+            />
+          )}
+        </div>
+
+        {/* Benchmark + dynamic coaching line */}
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-muted-foreground text-xs">
+            Ideal is{" "}
+            <span className="font-medium text-violet-500 dark:text-violet-400">
+              50% Needs
+            </span>{" "}
+            /{" "}
+            <span className="font-medium text-pink-500 dark:text-pink-400">
+              30% Wants
+            </span>{" "}
+            /{" "}
+            <span className="font-medium text-emerald-500 dark:text-emerald-400">
+              20% Saved
+            </span>
+            .
+          </p>
+          <p className="text-muted-foreground/80 text-xs italic">
+            {coachingNote(result)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/stats/calculations.ts
+++ b/src/lib/stats/calculations.ts
@@ -579,7 +579,11 @@ export function calculateBalancePrediction(
     return { available: false, reason: "insufficient-history" };
   }
 
-  const { window: historyWindow, mean: meanMonthlyNet, stdDev: stdDevMonthlyNet } = projection;
+  const {
+    window: historyWindow,
+    mean: meanMonthlyNet,
+    stdDev: stdDevMonthlyNet,
+  } = projection;
   const monthsUsed = historyWindow.length;
 
   // Confidence classification
@@ -620,6 +624,140 @@ export function calculateBalancePrediction(
       stdDevMonthlyNet,
       confidence,
     },
+  };
+}
+
+// --- Budget Split (Wants vs. Needs) ---
+
+export interface BudgetSplitResult {
+  /** Total essential spend (absolute value, rounded to cents). */
+  needs: number;
+  /** Total discretionary spend (absolute value, rounded to cents). */
+  wants: number;
+  /**
+   * Amount saved: max(0, income − outflow).
+   * Zero when spending exceeds income.
+   */
+  saved: number;
+  /** Percentage of income (or outflow) allocated to needs. */
+  needsPercentage: number;
+  /** Percentage of income (or outflow) allocated to wants. */
+  wantsPercentage: number;
+  /**
+   * Percentage of income allocated to savings (0 when in deficit).
+   * When saved > 0, denominator is income; else 0.
+   */
+  savedPercentage: number;
+  /**
+   * How much spending exceeded income this period (negative number).
+   * 0 when income ≥ outflow.
+   */
+  deficit: number;
+}
+
+/** Category names that map to essential / "Needs" spending. */
+const NEEDS_CATEGORIES = new Set<string>([
+  "Rent",
+  "Bills",
+  "Groceries",
+  "Transport",
+  "Healthcare",
+]);
+
+/** Category names that map to discretionary / "Wants" spending. */
+const WANTS_CATEGORIES = new Set<string>([
+  "Dining",
+  "Entertainment",
+  "Shopping",
+  "Subscriptions",
+  "Other",
+]);
+
+/**
+ * Splits all transactions into Needs / Wants / Saved buckets following the
+ * 50/30/20 budgeting framework.
+ *
+ * - Income  = sum of positive `tx.amount` values.
+ * - Needs   = absolute expense amounts whose category is in NEEDS_CATEGORIES.
+ * - Wants   = absolute expense amounts whose category is in WANTS_CATEGORIES.
+ * - Saved   = max(0, income − (needs + wants)).
+ * - Deficit = min(0, income − (needs + wants)) — negative when overspending.
+ *
+ * Percentages:
+ *   - When saved > 0: denominator = income (50/30/20 benchmark basis).
+ *   - When saved ≤ 0: denominator = outflow; savedPercentage = 0.
+ *   - When denominator = 0: all percentages = 0 (divide-by-zero guard).
+ *
+ * Uses `classifyTransaction` for transactions without a pre-set category,
+ * mirroring the pattern used by `calculateTopCategories`.
+ */
+export function calculateBudgetSplit(
+  transactions: readonly UnifiedTransaction[]
+): BudgetSplitResult {
+  let income = 0;
+  let needs = 0;
+  let wants = 0;
+
+  for (const tx of transactions) {
+    if (tx.amount > 0) {
+      income += tx.amount;
+      continue;
+    }
+
+    // Expense — classify then bucket
+    const category: string =
+      tx.category ?? classifyTransaction(tx.description, tx.counterparty);
+    const absAmount = Math.abs(tx.amount);
+
+    if (NEEDS_CATEGORIES.has(category)) {
+      needs += absAmount;
+    } else if (WANTS_CATEGORIES.has(category)) {
+      wants += absAmount;
+    }
+    // "Income" category on a negative tx (rare edge case) falls through untracked.
+  }
+
+  // Round to cents
+  income = Math.round(income * 100) / 100;
+  needs = Math.round(needs * 100) / 100;
+  wants = Math.round(wants * 100) / 100;
+
+  const outflow = Math.round((needs + wants) * 100) / 100;
+  const raw = income - outflow;
+  const saved = Math.round(Math.max(0, raw) * 100) / 100;
+  const deficit = Math.round(Math.min(0, raw) * 100) / 100;
+
+  // Percentage denominator: income when saving; outflow when overspending
+  let needsPercentage = 0;
+  let wantsPercentage = 0;
+  let savedPercentage = 0;
+
+  if (saved > 0) {
+    // 50/30/20 benchmark basis — denominator = income
+    const denom = income;
+    if (denom > 0) {
+      needsPercentage = Math.round((needs / denom) * 10000) / 100;
+      wantsPercentage = Math.round((wants / denom) * 10000) / 100;
+      savedPercentage = Math.round((saved / denom) * 10000) / 100;
+    }
+  } else {
+    // In deficit — show how needs vs wants share the outflow
+    const denom = outflow;
+    if (denom > 0) {
+      needsPercentage = Math.round((needs / denom) * 10000) / 100;
+      wantsPercentage = Math.round((wants / denom) * 10000) / 100;
+      // savedPercentage stays 0
+    }
+  }
+
+  return {
+    needs,
+    wants,
+    saved,
+    needsPercentage,
+    wantsPercentage,
+    savedPercentage,
+    deficit,
   };
 }
 


### PR DESCRIPTION
## What
Adds a full-width **Budget Allocation** strip to the **Insights** page that breaks spending into **Needs** (essential), **Wants** (discretionary), and **Saved** (income surplus), shown as a glassmorphic segmented bar benchmarked against the 50/30/20 rule.

## Why Insights (not the dashboard)
The original plan placed this on the main dashboard. Per the standing product direction to keep the dashboard a lean at-a-glance view, analytical/behavioral features live on the Insights page — so it ships there, alongside the Balance Projection and other analytics. Trivial to relocate if desired.

## Changes
- `calculateBudgetSplit()` pure helper + `BudgetSplitResult` type in `calculations.ts` (categories mapped via `classifyTransaction`)
- New `BudgetSplitStrip` presentational component — animated segmented bar, theme-aware borders, coaching line, amber deficit warning
- Mounted on Insights, computed client-side via `useMemo` — no dashboard or server-action changes

## Verification
- `npx tsc --noEmit` clean
- `npm run lint` 36 problems, all pre-existing; zero new
- Visual check in **both light and dark mode**: card, proportional Needs/Wants/Saved segments, and coaching line render correctly; light-mode legibility confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Budget Allocation section on the Insights page using the 50/30/20 framework
  * Displays breakdown of Needs, Wants, and Savings allocations
  * Visual progress indicators show budget allocation across categories
  * Deficit alerts when spending exceeds planned allocation
  * Dynamic coaching notes provide spending guidance

* **Documentation**
  * Updated project state documentation for completed budget allocation feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->